### PR TITLE
Placeholder text for date field on event form

### DIFF
--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -12,8 +12,6 @@ import DialogInput from '../interface/dialog/DialogInput';
 import Button from '../interface/Button';
 import styles from '../styles';
 
-import TextField from '@material-ui/core/TextField';
-
 class EventForm extends React.Component {
   constructor(props) {
     super(props);

--- a/src/components/events/EventForm.jsx
+++ b/src/components/events/EventForm.jsx
@@ -12,6 +12,8 @@ import DialogInput from '../interface/dialog/DialogInput';
 import Button from '../interface/Button';
 import styles from '../styles';
 
+import TextField from '@material-ui/core/TextField';
+
 class EventForm extends React.Component {
   constructor(props) {
     super(props);
@@ -76,7 +78,7 @@ class EventForm extends React.Component {
         <div style={{ margin: '25px' }}>
           <DialogInput fullWidth name="eventTitle" label="Event Title" onChange={this.handleChange} value={eventTitle} />
           <div style={{ display: 'flex' }}>
-            <DialogInput style={{ marginRight: '5px' }} fullWidth name="eventDate" label="Event Date" onChange={this.handleChange} value={eventDate} />
+            <DialogInput style={{ marginRight: '5px' }} fullWidth name="eventDate" label="Event Date" onChange={this.handleChange} placeholder="DD/MM/YYYY" value={eventDate} />
             <DialogInput fullWidth name="numJudges" label="No. Judges" onChange={this.handleChange} type="number" value={numJudges} />
           </div>
         </div>

--- a/src/components/interface/dialog/DialogInput.jsx
+++ b/src/components/interface/dialog/DialogInput.jsx
@@ -12,6 +12,7 @@ const DialogInput = ({
   label,
   multiline = false,
   onChange,
+  placeholder,
   style,
   type,
   value
@@ -27,6 +28,7 @@ const DialogInput = ({
     id={name}
     label={label}
     name={name}
+    placeholder={placeholder}
     type={type}
     value={value}
     margin="normal"
@@ -44,6 +46,7 @@ DialogInput.propTypes = {
   label: PropTypes.string,
   multiline: PropTypes.bool,
   onChange: PropTypes.func,
+  placeholder: PropTypes.string,
   style: PropTypes.shape(),
   type: PropTypes.string,
   value: PropTypes.node
@@ -57,6 +60,7 @@ DialogInput.defaultProps = {
   multiline: false,
   label: '',
   onChange: () => {},
+  placeholder: '',
   style: null,
   type: null,
   value: ''

--- a/src/components/interface/dialog/DialogInput.jsx
+++ b/src/components/interface/dialog/DialogInput.jsx
@@ -60,7 +60,7 @@ DialogInput.defaultProps = {
   multiline: false,
   label: '',
   onChange: () => {},
-  placeholder: '',
+  placeholder: 'DD/MM/YYYY',
   style: null,
   type: null,
   value: ''


### PR DESCRIPTION
Event form now has placeholder text specifying the input format ("DD/MM/YYYY") in the event date field.