### PR TITLE
Fix DialogInput Error

### DIFF
--- a/src/components/interface/dialog/DialogInput.jsx
+++ b/src/components/interface/dialog/DialogInput.jsx
@@ -63,7 +63,7 @@ DialogInput.defaultProps = {
   multiline: false,
   label: '',
   onChange: () => {},
-  placeholder: 'DD/MM/YYYY',
+  placeholder: '',
   style: null,
   type: null,
   value: ''


### PR DESCRIPTION
Remove DD/MM/YYYY as default DialogInput placeholder.