### PR TITLE
Save adjudication fields

### DIFF
--- a/src/components/adjudications/AdjudicationForm.jsx
+++ b/src/components/adjudications/AdjudicationForm.jsx
@@ -33,7 +33,7 @@ class AdjudicationForm extends React.Component {
 
   handleCheckedAward = (e) => {
     const { name, checked } = e.target;
-    this.setState({ [name]: checked });
+    this.setState({ [ name]: checked });
   }
 
   handleCancel = () => {
@@ -48,11 +48,16 @@ class AdjudicationForm extends React.Component {
 
   // TODO: handle submmission of the form
   handleSubmit = async () => {
-    const { adjudicationId, collectionName } = this.props;
+    const { adjudicationId, collectionName, currentValues } = this.props;
     const { artisticMark, technicalMark } = this.state;
+    const { audioURL, judgeName, notes } = currentValues;
+
     const cumulativeMark = (parseInt(artisticMark, 10) + parseInt(technicalMark, 10)) / 2;
     const data = {
+      audioURL,
       cumulativeMark,
+      judgeName,
+      notes,
       ...this.state
     };
     await updateData(

--- a/src/components/adjudications/AdjudicationForm.jsx
+++ b/src/components/adjudications/AdjudicationForm.jsx
@@ -46,15 +46,17 @@ class AdjudicationForm extends React.Component {
     }
   }
 
-  // TODO: handle submmission of the form
   handleSubmit = async () => {
     const { 
       adjudicationId, 
       collectionName, 
-      currentValues : {audioURL, judgeName, notes} 
+      currentValues : {
+        audioURL, 
+        judgeName, 
+        notes
+      } 
     } = this.props;
     const { artisticMark, technicalMark } = this.state;
-
     const cumulativeMark = (parseInt(artisticMark, 10) + parseInt(technicalMark, 10)) / 2;
     const data = {
       audioURL,

--- a/src/components/adjudications/AdjudicationForm.jsx
+++ b/src/components/adjudications/AdjudicationForm.jsx
@@ -48,9 +48,12 @@ class AdjudicationForm extends React.Component {
 
   // TODO: handle submmission of the form
   handleSubmit = async () => {
-    const { adjudicationId, collectionName, currentValues } = this.props;
+    const { 
+      adjudicationId, 
+      collectionName, 
+      currentValues : {audioURL, judgeName, notes} 
+    } = this.props;
     const { artisticMark, technicalMark } = this.state;
-    const { audioURL, judgeName, notes } = currentValues;
 
     const cumulativeMark = (parseInt(artisticMark, 10) + parseInt(technicalMark, 10)) / 2;
     const data = {

--- a/src/components/adjudications/AdjudicationForm.jsx
+++ b/src/components/adjudications/AdjudicationForm.jsx
@@ -33,7 +33,7 @@ class AdjudicationForm extends React.Component {
 
   handleCheckedAward = (e) => {
     const { name, checked } = e.target;
-    this.setState({ [ name]: checked });
+    this.setState({ [name]: checked });
   }
 
   handleCancel = () => {


### PR DESCRIPTION
Fix for Issue #46 
When Adjudication Form is submitted with the edits for `artisticMark`, `technicalMark`, `choreoAward`, and `specialAward`, the other fields of the adjudication object in the database are preserved.