### PR TITLE
[Feature]: Data Seeding

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ performance scoring.
 │   ├── migrations
 │   ├── schema.prisma # Prisma schema
 │   └── schema.sql # SQL schema conforming to Prisma
+│   └── seed.js # Prisma seeding scripts
 ├── public # Public outputs
 │   ├── favicon.ico
 │   └── vectors
@@ -69,6 +70,9 @@ heroku pg:psql -a YOUR_APP_NAME -f prisma/schema.sql
 
 # Regenerate Prisma schema and client
 npx prisma introspect && npx prisma generate
+
+# Seeding the database with sample data
+npx prisma db seed --preview-feature
 ```
 
 To run the application:

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -63,6 +63,7 @@ model Setting {
   created_at DateTime    @default(now()) @db.Timestamp(6)
   updated_at DateTime    @default(now()) @db.Timestamp(6)
 
+  @@unique([type, value], name: "settings_unique")
   @@map("settings")
 }
 

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -103,3 +103,4 @@ CREATE TABLE contacts (
   FOREIGN KEY(school_id) REFERENCES schools(id)
 );
 
+ALTER TABLE settings ADD CONSTRAINT "settings_unique" UNIQUE (type, value);

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,62 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  // TODO: perform data seeding dependent on environment
+  await userSeed();
+  await dataSeed();
+}
+
+async function dataSeed() {
+  // TODO: seed some sample data
+}
+
+async function userSeed() {
+  const eric = await prisma.user.upsert({
+    where: { email: 'ericli@uwblueprint.org' },
+    update: {
+      role: 'ADMIN',
+      name: 'Eric',
+    },
+    create: {
+      role: 'ADMIN',
+      email: `ericli@uwblueprint.org`,
+      name: 'Eric',
+    },
+  });
+  const julia = await prisma.user.upsert({
+    where: { email: 'juliasim@uwblueprint.org' },
+    update: {
+      role: 'ADMIN',
+      name: 'Julia',
+    },
+    create: {
+      role: 'ADMIN',
+      email: `juliasim@uwblueprint.org`,
+      name: 'Julia',
+    },
+  });
+  const dancefest = await prisma.user.upsert({
+    where: { email: 'dancefest@uwblueprint.org' },
+    update: {
+      role: 'ADMIN',
+      name: 'Dancefest',
+    },
+    create: {
+      role: 'ADMIN',
+      email: `dancefest@uwblueprint.org`,
+      name: 'Dancefest',
+    },
+  });
+  console.log({ eric, julia, dancefest });
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -10,6 +10,68 @@ async function main() {
 
 async function dataSeed() {
   // TODO: seed some sample data
+  const sizeSettings = ['Small Group', 'Medium Group', 'Large Group', 'Creative Collaboration'];
+  const styleSettings = [
+    'Jazz',
+    'Lyrical',
+    'Ballet',
+    'Open/Fusion',
+    'Modern/Contemporary',
+    'Hip Hop',
+    'Tap',
+    'Cultural',
+    'Musical Theatre',
+    'Live Vocals',
+  ];
+  const levelSettings = ['Easy', 'Intermediate', 'Advanced'];
+  // TODO: add some logging for batch upserts
+  for (let size of sizeSettings) {
+    await prisma.setting.upsert({
+      where: {
+        settings_unique: {
+          type: 'DANCE_SIZE',
+          value: size,
+        },
+      },
+      update: {},
+      create: {
+        type: 'DANCE_SIZE',
+        value: size,
+      },
+    });
+  }
+
+  for (let style of styleSettings) {
+    await prisma.setting.upsert({
+      where: {
+        settings_unique: {
+          type: 'STYLE',
+          value: style,
+        },
+      },
+      update: {},
+      create: {
+        type: 'STYLE',
+        value: style,
+      },
+    });
+  }
+
+  for (let level of levelSettings) {
+    await prisma.setting.upsert({
+      where: {
+        settings_unique: {
+          type: 'COMPETITION_LEVEL',
+          value: level,
+        },
+      },
+      update: {},
+      create: {
+        type: 'COMPETITION_LEVEL',
+        value: level,
+      },
+    });
+  }
 }
 
 async function userSeed() {


### PR DESCRIPTION
**Requires:** 
Schema change to due the addition of unique constraint in settings.

**Description:**
Add some basic seeding functionality.
Feel free to build on this and we will separate seeding in the future based on environment type.

**Testing:**

Run the following commands on an empty database (either reset your database or setup a new one):

```
# Deploy schema.sql to Heroku postgres
heroku pg:psql -a YOUR_APP_NAME -f prisma/schema.sql

# Regenerate Prisma schema and client
npx prisma introspect && npx prisma generate

# Seeding the database with sample data
npx prisma db seed --preview-feature
```

Verify that settings table and users table are populated with sample data.