### PR TITLE
[Bugfix]: Fix Settings page bugs

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -31,7 +31,10 @@ export default function Modal({
       isOpen={open}
       className={`${styles.modal__container} ${containerClassName}`}
       overlayClassName={styles.modal__overlay}
-      onRequestClose={() => setModalOpen(false)}
+      onRequestClose={() => {
+        onCancel();
+        setModalOpen(false);
+      }}
       {...props}
     >
       {title ? <Title>{title}</Title> : null}

--- a/components/settings/AdminModal.js
+++ b/components/settings/AdminModal.js
@@ -17,13 +17,10 @@ export default function AdminModal({
   const [adminName, setAdminName] = useState('');
   const [adminEmail, setAdminEmail] = useState('');
 
-  useEffect(() => {
-    if (adminToEdit) {
-      const { name, email } = adminToEdit;
-      setAdminName(name);
-      setAdminEmail(email);
-    }
-  }, [adminToEdit]);
+  const clearFields = () => {
+    setAdminName('');
+    setAdminEmail('');
+  };
 
   const updateAdmin = async () => {
     setLoading(true);
@@ -48,13 +45,13 @@ export default function AdminModal({
     setOpen(false);
   };
 
-  const upsertAdmin = async () => {
+  const addAdmin = async () => {
     setLoading(true);
 
     try {
       await axios({
-        method: 'PUT',
-        url: '/api/user/upsert',
+        method: 'POST',
+        url: '/api/user/create',
         data: {
           name: adminName,
           email: adminEmail,
@@ -71,6 +68,16 @@ export default function AdminModal({
     setOpen(false);
   };
 
+  useEffect(() => {
+    if (adminToEdit) {
+      const { name, email } = adminToEdit;
+      setAdminName(name);
+      setAdminEmail(email);
+    } else {
+      clearFields();
+    }
+  }, [adminToEdit]);
+
   return (
     <Modal
       containerClassName={styles.adminModal__container}
@@ -79,8 +86,12 @@ export default function AdminModal({
       cancelText="Discard"
       submitText={adminToEdit ? 'Edit Admin' : 'Add Admin'}
       setModalOpen={setOpen}
-      onCancel={() => setOpen(false)}
-      onSubmit={adminToEdit ? updateAdmin : upsertAdmin}
+      onCancel={() => {
+        setOpen(false);
+        setAdminToEdit(null);
+        clearFields();
+      }}
+      onSubmit={adminToEdit ? updateAdmin : addAdmin}
       disableSubmitButton={!adminName || !adminEmail}
     >
       <div className={styles.adminModal}>

--- a/components/settings/SchoolModal.js
+++ b/components/settings/SchoolModal.js
@@ -19,15 +19,12 @@ export default function SchoolModal({
   const [contactEmail, setContactEmail] = useState('');
   const [phoneNumber, setPhoneNumber] = useState('');
 
-  useEffect(() => {
-    if (schoolToEdit) {
-      const { school_name, contact_name, email, phone } = schoolToEdit;
-      setSchoolName(school_name);
-      setContactName(contact_name);
-      setContactEmail(email);
-      setPhoneNumber(phone);
-    }
-  }, [schoolToEdit]);
+  const clearFields = () => {
+    setSchoolName('');
+    setContactName('');
+    setContactEmail('');
+    setPhoneNumber('');
+  };
 
   const updateSchool = async () => {
     setLoading(true);
@@ -78,6 +75,18 @@ export default function SchoolModal({
     setOpen(false);
   };
 
+  useEffect(() => {
+    if (schoolToEdit) {
+      const { school_name, contact_name, email, phone } = schoolToEdit;
+      setSchoolName(school_name);
+      setContactName(contact_name);
+      setContactEmail(email);
+      setPhoneNumber(phone);
+    } else {
+      clearFields();
+    }
+  }, [schoolToEdit]);
+
   return (
     <Modal
       containerClassName={styles.schoolModal__container}
@@ -86,7 +95,11 @@ export default function SchoolModal({
       cancelText="Discard"
       submitText={schoolToEdit ? 'Edit School' : 'Add School'}
       setModalOpen={setOpen}
-      onCancel={() => setOpen(false)}
+      onCancel={() => {
+        setOpen(false);
+        setSchoolToEdit(null);
+        clearFields();
+      }}
       onSubmit={schoolToEdit ? updateSchool : addSchool}
       disableSubmitButton={!schoolName || !contactName || !contactEmail || !phoneNumber}
     >

--- a/pages/api/settings/delete.js
+++ b/pages/api/settings/delete.js
@@ -12,7 +12,7 @@ export default async (req, res) => {
 
     // Check that id exists
     if (!id) {
-      res.status(400).send({
+      return res.status(400).json({
         error: 'ID was not provided',
       });
     }
@@ -24,7 +24,7 @@ export default async (req, res) => {
       },
     });
     if (!setting) {
-      res.status(400).send({
+      return res.status(400).json({
         error: 'The specified setting ID does not exist',
       });
     }
@@ -47,8 +47,8 @@ export default async (req, res) => {
     const performancesUsingSetting = await prisma.performance.findMany({
       where: performancesFilter,
     });
-    if (performancesUsingSetting) {
-      res.status(400).send({
+    if (performancesUsingSetting.length > 0) {
+      return res.status(400).json({
         error: 'Options in use cannot be deleted',
       });
     }

--- a/pages/api/user/create.js
+++ b/pages/api/user/create.js
@@ -13,13 +13,23 @@ export default async (req, res) => {
     // If name and email are defined
     if (name && email) {
       // Create new user
-      const user = await prisma.user.create({
-        data: {
-          name,
-          role: role || 'USER',
-          email,
-        },
-      });
+      let user;
+      try {
+        user = await prisma.user.create({
+          data: {
+            name,
+            role: role || 'USER',
+            email,
+          },
+        });
+      } catch (err) {
+        if (err.code === 'P2002' && err.meta.target.includes('email')) {
+          // Fails unique email check
+          return res.status(400).json({
+            error: `A user already exists with email ${email}`,
+          });
+        }
+      }
 
       // If user creation is successful, return user
       if (user) {


### PR DESCRIPTION
Fixes the following bugs:
- Deleting setting value resulting in server error (due to not returning the `res.status(400)` in the API)
- Admin/school modal fields not resetting after closing the modal
- Admin/school still in editing mode even after API request succeeded (which caused new adds to edit the previously edited entry)

New:
- Raise a 400 when creating a new admin with an email that is already being used for another user