### PR TITLE
[Bugfix]: Update Performances Table page size, Fix Admin Modal button bug

### DIFF
--- a/components/performances/PerformancesTable.js
+++ b/components/performances/PerformancesTable.js
@@ -7,7 +7,7 @@ import EmptyTableComponent from '@components/performances/EmptyTableComponent'; 
 import Table from '@components/Table'; // Table
 import Button from '@components/Button'; // Button
 
-const PAGE_SIZE = 3; // Rows per page
+const PAGE_SIZE = 20; // Rows per page
 
 export default function PerformancesTable({
   performances,

--- a/styles/components/settings/AdminModal.module.scss
+++ b/styles/components/settings/AdminModal.module.scss
@@ -4,7 +4,7 @@ Add/Edit Admin Modal
 ****************************************
 */
 .adminModal__container {
-  height: 412px;
+  height: 500px;
   width: 1028px;
   max-width: 1028px;
 


### PR DESCRIPTION
- Change number of rows per page in Performances Table from 3 to 20
- Fix a bug in Admin Modal where the Discard and Submit buttons were only clickable from a slim margin at the bottom