### PR TITLE
[Feature]: Moved user_id to awards_performances 

### DIFF
--- a/pages/api/awards/collect.js
+++ b/pages/api/awards/collect.js
@@ -32,14 +32,15 @@ export const getAwards = async () => {
   if (!awards) return;
 
   // Remove the relation table data
-  return awards.map(award => {
+  return awards.map(({ awards_performances, ...rest }) => {
     return {
-      ...award,
-      awards_performances: award.awards_performances.map(performance => {
+      ...rest,
+      performances: awards_performances.map(({ performances, nominee_count, status, user_id }) => {
         return {
-          ...performance.performances,
-          nominee_count: performance.nominee_count,
-          status: performance.status,
+          ...performances,
+          nominee_count,
+          status,
+          user_id,
         };
       }),
     };

--- a/pages/api/awards/create.js
+++ b/pages/api/awards/create.js
@@ -11,13 +11,11 @@ export default async (req, res) => {
     return res.status(401).end();
   }
 
-  const userID = session.id;
-
   // Collect award information from request body
   const { title, settingIDs } = req.body;
 
   // If required fields do not exist
-  if (!title || !userID) {
+  if (!title) {
     return res.status(400).json({
       error: 'Required fields not provided',
     });
@@ -29,7 +27,6 @@ export default async (req, res) => {
     const award = await prisma.award.create({
       data: {
         title: title,
-        user_id: userID,
         is_category: isCategory,
       },
     });

--- a/pages/api/awards/get.js
+++ b/pages/api/awards/get.js
@@ -50,12 +50,15 @@ export const getAward = async filter => {
   // Remove the relation table data
   return {
     ...award,
-    awards_performances: award.awards_performances.map(performance => {
-      return {
-        ...performance.performances,
-        nominee_count: performance.nominee_count,
-        status: performance.status,
-      };
-    }),
+    awards_performances: award.awards_performances.map(
+      ({ performances, nominee_count, status, user_id }) => {
+        return {
+          ...performances,
+          nominee_count,
+          status,
+          user_id,
+        };
+      }
+    ),
   };
 };

--- a/pages/api/performances/collect.js
+++ b/pages/api/performances/collect.js
@@ -62,11 +62,12 @@ export const getPerformances = async filter => {
     ({ awards_performances, event: { judges: judgesString }, adjudications, ...rest }) => {
       return {
         ...rest,
-        awards: awards_performances.map(({ awards, nominee_count, status }) => {
+        awards: awards_performances.map(({ awards, nominee_count, status, user_id }) => {
           return {
             ...awards,
             nominee_count,
             status,
+            user_id,
           };
         }),
         totalAdjudications: (JSON.parse(judgesString) || []).filter(judge => judge !== '').length,

--- a/pages/api/performances/get.js
+++ b/pages/api/performances/get.js
@@ -56,12 +56,15 @@ export const getPerformance = async filter => {
   // Remove the relation table data
   return {
     ...performance,
-    awards_performances: performance.awards_performances.map(award => {
-      return {
-        ...award.awards,
-        nominee_count: award.nominee_count,
-        status: award.status,
-      };
-    }),
+    awards_performances: performance.awards_performances.map(
+      ({ awards, nominee_count, status, user_id }) => {
+        return {
+          ...awards,
+          nominee_count,
+          status,
+          user_id,
+        };
+      }
+    ),
   };
 };

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -14,6 +14,8 @@ export default async (req, res) => {
     });
   }
 
+  const userID = session.id;
+
   // Collect performance id and award ids from request body
   const { performanceID, awardIDs } = req.body;
 
@@ -49,6 +51,7 @@ export default async (req, res) => {
           create: {
             award_id: awardID,
             performance_id: performanceID,
+            user_id: userID,
             nominee_count: 1,
           },
           update: {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,16 +8,16 @@ datasource db {
 }
 
 model User {
-  id            Int            @id @default(autoincrement())
-  name          String?        @db.VarChar(255)
-  role          role           @default(USER)
-  email         String?        @unique @db.VarChar(255)
-  emailVerified DateTime?      @map("email_verified") @db.Timestamptz(6)
-  image         String?
-  created_at    DateTime       @default(now()) @db.Timestamptz(6)
-  updated_at    DateTime       @default(now()) @db.Timestamptz(6)
-  adjudications Adjudication[] @relation("adjudicationsTousers")
-  awards        Award[]        @relation("awardsTousers")
+  id                  Int                @id @default(autoincrement())
+  name                String?            @db.VarChar(255)
+  role                role               @default(USER)
+  email               String?            @unique @db.VarChar(255)
+  emailVerified       DateTime?          @map("email_verified") @db.Timestamptz(6)
+  image               String?
+  created_at          DateTime           @default(now()) @db.Timestamptz(6)
+  updated_at          DateTime           @default(now()) @db.Timestamptz(6)
+  adjudications       Adjudication[]     @relation("adjudicationsTousers")
+  awards_performances AwardPerformance[] @relation("awards_performancesTousers")
 
   @@map("users")
 }
@@ -117,10 +117,8 @@ model Award {
   title               String             @db.VarChar(255)
   is_finalized        Boolean            @default(false)
   is_category         Boolean            @default(false)
-  user_id             Int
   created_at          DateTime           @default(now()) @db.Timestamp(6)
   updated_at          DateTime           @default(now()) @db.Timestamp(6)
-  user                User               @relation("awardsTousers", fields: [user_id], references: [id])
   awards_categories   AwardCategory[]    @relation("awardsToawards_categories")
   awards_performances AwardPerformance[] @relation("awardsToawards_performances")
 
@@ -131,10 +129,12 @@ model AwardPerformance {
   id             Int                    @id @default(autoincrement())
   award_id       Int?
   performance_id Int?
+  user_id        Int
   nominee_count  Int?                   @default(0)
   status         awardperformancestatus @default(NOMINEE)
   awards         Award?                 @relation("awardsToawards_performances", fields: [award_id], references: [id])
   performances   Performance?           @relation("awards_performancesToperformances", fields: [performance_id], references: [id])
+  users          User                   @relation("awards_performancesTousers", fields: [user_id], references: [id])
 
   @@unique([award_id, performance_id], name: "awards_performances_unique")
   @@map("awards_performances")

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -104,10 +104,8 @@ CREATE TABLE awards (
   title VARCHAR(255) NOT NULL,
   is_finalized BOOLEAN NOT NULL DEFAULT FALSE,
   is_category BOOLEAN NOT NULL DEFAULT FALSE,
-  user_id INTEGER NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY(user_id) REFERENCES users(id)
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Create award categories table
@@ -125,9 +123,11 @@ CREATE TABLE awards_performances (
   id SERIAL PRIMARY KEY NOT NULL,
   award_id INTEGER,
   performance_id INTEGER,
+  user_id INTEGER NOT NULL,
   nominee_count INTEGER DEFAULT 0,
   status AwardPerformanceStatus NOT NULL DEFAULT 'NOMINEE',
   FOREIGN KEY(award_id) REFERENCES awards(id),
   FOREIGN KEY(performance_id) REFERENCES performances(id),
+  FOREIGN KEY(user_id) REFERENCES users(id),
   CONSTRAINT "awards_performances_unique" UNIQUE (award_id, performance_id)
 );


### PR DESCRIPTION
**Requires:**
- Schema Upgrade

**Description:**
- Moved user_id field to awards_performances table 
- For the response of awards/collect.js, I changed the field name from 'award_performances' to 'performances' inside each awards object