### PR TITLE
Feature awards seeding + removing nominee_count field and adding user_id to unique constraint for awards_performances

### DIFF
--- a/pages/api/awards/collect.js
+++ b/pages/api/awards/collect.js
@@ -35,10 +35,9 @@ export const getAwards = async () => {
   return awards.map(({ awards_performances, ...rest }) => {
     return {
       ...rest,
-      performances: awards_performances.map(({ performances, nominee_count, status, user_id }) => {
+      performances: awards_performances.map(({ performances, status, user_id }) => {
         return {
           ...performances,
-          nominee_count,
           status,
           user_id,
         };

--- a/pages/api/awards/get.js
+++ b/pages/api/awards/get.js
@@ -50,15 +50,12 @@ export const getAward = async filter => {
   // Remove the relation table data
   return {
     ...award,
-    awards_performances: award.awards_performances.map(
-      ({ performances, nominee_count, status, user_id }) => {
-        return {
-          ...performances,
-          nominee_count,
-          status,
-          user_id,
-        };
-      }
-    ),
+    awards_performances: award.awards_performances.map(({ performances, status, user_id }) => {
+      return {
+        ...performances,
+        status,
+        user_id,
+      };
+    }),
   };
 };

--- a/pages/api/performances/collect.js
+++ b/pages/api/performances/collect.js
@@ -62,10 +62,9 @@ export const getPerformances = async filter => {
     ({ awards_performances, event: { judges: judgesString }, adjudications, ...rest }) => {
       return {
         ...rest,
-        awards: awards_performances.map(({ awards, nominee_count, status, user_id }) => {
+        awards: awards_performances.map(({ awards, status, user_id }) => {
           return {
             ...awards,
-            nominee_count,
             status,
             user_id,
           };

--- a/pages/api/performances/get.js
+++ b/pages/api/performances/get.js
@@ -56,15 +56,12 @@ export const getPerformance = async filter => {
   // Remove the relation table data
   return {
     ...performance,
-    awards_performances: performance.awards_performances.map(
-      ({ awards, nominee_count, status, user_id }) => {
-        return {
-          ...awards,
-          nominee_count,
-          status,
-          user_id,
-        };
-      }
-    ),
+    awards_performances: performance.awards_performances.map(({ awards, status, user_id }) => {
+      return {
+        ...awards,
+        status,
+        user_id,
+      };
+    }),
   };
 };

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -35,30 +35,23 @@ export default async (req, res) => {
 
   // TODO for now we assume frontend will filter correctly and only
   // eligible awards will show up for validation
-
-  // We update the nominee_count if the performance has been already been nominated for the award
-  // If it does not exist, we create an entry into the association table
   try {
     const awardPerformances = await prisma.$transaction(
       awardIDs.map(awardID =>
         prisma.awardPerformance.upsert({
           where: {
-            awards_performances_unique: {
+            unique_nomination: {
               award_id: awardID,
               performance_id: performanceID,
+              user_id: userID,
             },
           },
           create: {
             award_id: awardID,
             performance_id: performanceID,
             user_id: userID,
-            nominee_count: 1,
           },
-          update: {
-            nominee_count: {
-              increment: 1,
-            },
-          },
+          update: {},
         })
       )
     );

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,13 +130,12 @@ model AwardPerformance {
   award_id       Int?
   performance_id Int?
   user_id        Int
-  nominee_count  Int?                   @default(0)
   status         awardperformancestatus @default(NOMINEE)
   awards         Award?                 @relation("awardsToawards_performances", fields: [award_id], references: [id])
   performances   Performance?           @relation("awards_performancesToperformances", fields: [performance_id], references: [id])
   users          User                   @relation("awards_performancesTousers", fields: [user_id], references: [id])
 
-  @@unique([award_id, performance_id], name: "awards_performances_unique")
+  @@unique([award_id, performance_id, user_id], name: "unique_nomination")
   @@map("awards_performances")
 }
 

--- a/prisma/schema.sql
+++ b/prisma/schema.sql
@@ -124,10 +124,9 @@ CREATE TABLE awards_performances (
   award_id INTEGER,
   performance_id INTEGER,
   user_id INTEGER NOT NULL,
-  nominee_count INTEGER DEFAULT 0,
   status AwardPerformanceStatus NOT NULL DEFAULT 'NOMINEE',
   FOREIGN KEY(award_id) REFERENCES awards(id),
   FOREIGN KEY(performance_id) REFERENCES performances(id),
   FOREIGN KEY(user_id) REFERENCES users(id),
-  CONSTRAINT "awards_performances_unique" UNIQUE (award_id, performance_id)
+  CONSTRAINT "unique_nomination" UNIQUE (award_id, performance_id, user_id)
 );

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -30,15 +30,15 @@ async function dataSeed() {
 
   for (const admin of admins) {
     const adminUpsert = await prisma.user.upsert({
-      where: { email: admin['email'] },
+      where: { email: admin.email },
       update: {
         role: 'ADMIN',
-        name: admin['name'],
+        name: admin.name,
       },
       create: {
         role: 'ADMIN',
-        email: admin['email'],
-        name: admin['name'],
+        email: admin.email,
+        name: admin.name,
       },
     });
     console.log({ adminUpsert });
@@ -47,15 +47,15 @@ async function dataSeed() {
   const userUpserts = [];
   for (const user of users) {
     const userUpsert = await prisma.user.upsert({
-      where: { email: user['email'] },
+      where: { email: user.email },
       update: {
         role: 'ADMIN',
-        name: user['name'],
+        name: user.name,
       },
       create: {
         role: 'ADMIN',
-        email: user['email'],
-        name: user['name'],
+        email: user.email,
+        name: user.name,
       },
     });
     userUpserts.push(userUpsert);
@@ -135,14 +135,14 @@ async function dataSeed() {
   // EVENT SEEDING
   const eventUpsert = await prisma.event.upsert({
     where: {
-      id: event['id'],
+      id: event.id,
     },
     update: {
-      name: event['name'],
+      name: event.name,
     },
     create: {
-      id: event['id'],
-      name: event['name'],
+      id: event.id,
+      name: event.name,
     },
   });
 
@@ -161,14 +161,14 @@ async function dataSeed() {
   const schoolUpserts = [];
   for (const school of schools) {
     const schoolUpsert = await prisma.school.upsert({
-      where: { id: school['id'] },
+      where: { id: school.id },
       update: {
-        school_name: school['school_name'],
+        school_name: school.school_name,
       },
       create: {
-        id: school['id'],
-        school_name: school['school_name'],
-        email: school['email'],
+        id: school.id,
+        school_name: school.school_name,
+        email: school.email,
       },
     });
     schoolUpserts.push(schoolUpsert);
@@ -210,23 +210,23 @@ async function dataSeed() {
   for (const performance of performances) {
     const performanceUpsert = await prisma.performance.upsert({
       where: {
-        id: performance['id'],
+        id: performance.id,
       },
       update: {
-        name: performance['name'],
-        performers: performance['performers'],
-        choreographers: performance['cheoreographers'],
-        event_id: performance['event_id'],
-        school_id: performance['school_id'],
+        name: performance.name,
+        performers: performance.performers,
+        choreographers: performance.cheoreographers,
+        event_id: performance.event_id,
+        school_id: performance.school_id,
       },
       create: {
-        id: performance['id'],
-        name: performance['name'],
-        performers: performance['performers'],
-        choreographers: performance['cheoreographers'],
-        dance_entry: performance['dance_entry'],
-        event_id: performance['event_id'],
-        school_id: performance['school_id'],
+        id: performance.id,
+        name: performance.name,
+        performers: performance.performers,
+        choreographers: performance.cheoreographers,
+        dance_entry: performance.dance_entry,
+        event_id: performance.event_id,
+        school_id: performance.school_id,
       },
     });
     performanceUpserts.push(performanceUpsert);
@@ -265,20 +265,20 @@ async function dataSeed() {
   for (const adjudication of ajudications) {
     const adjudicationUpsert = await prisma.adjudication.upsert({
       where: {
-        id: adjudication['id'],
+        id: adjudication.id,
       },
       update: {
-        artistic_mark: adjudication['artistic_mark'],
-        technical_mark: adjudication['technical_mark'],
-        cumulative_mark: adjudication['cumulative_mark'],
+        artistic_mark: adjudication.artistic_mark,
+        technical_mark: adjudication.technical_mark,
+        cumulative_mark: adjudication.cumulative_mark,
       },
       create: {
-        id: adjudication['id'],
-        artistic_mark: adjudication['artistic_mark'],
-        technical_mark: adjudication['technical_mark'],
-        cumulative_mark: adjudication['cumulative_mark'],
-        performance_id: adjudication['performance_id'],
-        user_id: adjudication['user_id'],
+        id: adjudication.id,
+        artistic_mark: adjudication.artistic_mark,
+        technical_mark: adjudication.technical_mark,
+        cumulative_mark: adjudication.cumulative_mark,
+        performance_id: adjudication.performance_id,
+        user_id: adjudication.user_id,
       },
     });
     adjudicationUpserts.push(adjudicationUpsert);
@@ -312,16 +312,16 @@ async function dataSeed() {
   for (const award of awards) {
     const awardUpsert = await prisma.award.upsert({
       where: {
-        id: award['id'],
+        id: award.id,
       },
       update: {
-        title: award['title'],
-        is_category: award['is_category'],
+        title: award.title,
+        is_category: award.is_category,
       },
       create: {
-        id: award['id'],
-        title: award['title'],
-        is_category: award['is_category'],
+        id: award.id,
+        title: award.title,
+        is_category: award.is_category,
       },
     });
     awardUpserts.push(awardUpsert);
@@ -331,16 +331,16 @@ async function dataSeed() {
       const awardCategoryUpsert = await prisma.awardCategory.upsert({
         where: {
           awards_categories_unique: {
-            award_id: award['id'],
+            award_id: award.id,
             category_id: styleSettingUpserts[0].id,
           },
         },
         update: {
-          award_id: award['id'],
+          award_id: award.id,
           category_id: styleSettingUpserts[0].id,
         },
         create: {
-          award_id: award['id'],
+          award_id: award.id,
           category_id: styleSettingUpserts[0].id,
         },
       });

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -94,6 +94,7 @@ async function dataSeed() {
     console.log(setting);
   }
 
+  const styleSettingUpserts = [];
   for (const style of styleSettings) {
     const setting = await prisma.setting.upsert({
       where: {
@@ -109,6 +110,7 @@ async function dataSeed() {
       },
     });
     console.log(setting);
+    styleSettingUpserts.push(setting);
   }
 
   for (const level of levelSettings) {
@@ -281,6 +283,69 @@ async function dataSeed() {
     });
     adjudicationUpserts.push(adjudicationUpsert);
     console.log(adjudicationUpsert);
+  }
+
+  const awards = [
+    {
+      id: 1,
+      title: 'Award 1',
+      is_category: false,
+    },
+    {
+      id: 2,
+      title: 'Award 2',
+      is_category: false,
+    },
+    {
+      id: 3,
+      title: 'Award 3',
+      is_category: true,
+    },
+    {
+      id: 4,
+      title: 'Award 4',
+      is_category: true,
+    },
+  ];
+
+  const awardUpserts = [];
+  for (const award of awards) {
+    const awardUpsert = await prisma.award.upsert({
+      where: {
+        id: award['id'],
+      },
+      update: {
+        title: award['title'],
+        is_category: award['is_category'],
+      },
+      create: {
+        id: award['id'],
+        title: award['title'],
+        is_category: award['is_category'],
+      },
+    });
+    awardUpserts.push(awardUpsert);
+    console.log(awardUpsert);
+
+    if (award['is_category']) {
+      const awardCategoryUpsert = await prisma.awardCategory.upsert({
+        where: {
+          awards_categories_unique: {
+            award_id: award['id'],
+            category_id: styleSettingUpserts[0].id,
+          },
+        },
+        update: {
+          award_id: award['id'],
+          category_id: styleSettingUpserts[0].id,
+        },
+        create: {
+          award_id: award['id'],
+          category_id: styleSettingUpserts[0].id,
+        },
+      });
+      console.log(awardCategoryUpsert);
+    }
   }
 }
 


### PR DESCRIPTION
- Basic seeding into awards table and awards category table
- Added user_id to unique constraint to awards_performances tuple
- Removed nominee_count field from awards_performances
- Refactored existing routes to accommodate these changes 
- Tested nominating performance for multiple awards, tested nominating different performances for the same award, tested finalizing a performance for an award, tested attempting to finalize an award that is already finalized, which will throw an error.
- NOTE: Schema changes to this PR