### PR TITLE
[Improvement]: Change Performances Table routing, move Edit Performances Modal to Performance Details

### DIFF
--- a/components/Table.js
+++ b/components/Table.js
@@ -70,11 +70,6 @@ export default function Table({
     setAllFilters(filters);
   }, [filters]);
 
-  const handleRowClick = row => () => {
-    // Call the prop - onRowClick
-    onRowClick(row);
-  };
-
   return (
     <div className={styles.table__div}>
       {data && data.length === 0 ? (
@@ -121,7 +116,7 @@ export default function Table({
             {(paginate ? page : rows).map((row, i) => {
               prepareRow(row);
               return clickable ? (
-                <tr key={i} {...row.getRowProps()} onClick={handleRowClick(row)}>
+                <tr key={i} {...row.getRowProps()} onClick={() => onRowClick(row)}>
                   {row.cells.map((cell, i) => {
                     return (
                       <td key={i} {...cell.getCellProps()}>

--- a/components/performance-details/EditPerformanceModal.js
+++ b/components/performance-details/EditPerformanceModal.js
@@ -69,6 +69,9 @@ export default function EditPerformanceModal({
       const danceStyleSettings = settings.filter(setting => setting.type === 'STYLE');
       const danceSizeSettings = settings.filter(setting => setting.type === 'DANCE_SIZE');
 
+      // Set the label of each dropdown option to the `value` field of each setting (the setting name in the DB)
+      // Set the selected value (which is sent to API upon save) to the `id` field of each setting (the setting id in the DB)
+      // upon clicking a dropdown option
       const formatOptionsFields = {
         value: 'id',
         label: 'value',

--- a/components/performance-details/EditPerformanceModal.js
+++ b/components/performance-details/EditPerformanceModal.js
@@ -1,27 +1,24 @@
 import React, { useState, useEffect } from 'react'; // React
 import PropTypes from 'prop-types'; // PropTypes
 import axios from 'axios'; // axios
+import Navigation from '@containers/Navigation'; // Navigation state
 
 import Input from '@components/Input'; // Input
 import Modal from '@components/Modal'; // Modal
-import Dropdown from '@components/Dropdown'; // Dropdown
+import Dropdown, { formatDropdownOptions } from '@components/Dropdown'; // Dropdown
 import styles from '@styles/components/performances/PerformanceModal.module.scss'; // Component styles
 
-const EVENT_ID = 1; // Temp event id
+import { formatSchools } from '@utils/schools'; // Format schools util
 
-export default function PerformanceModal({
+export default function EditPerformanceModal({
   open,
   setOpen,
   setLoading,
-  getPerformances,
-  addPerformance,
-  schoolOptions,
-  performanceLevelOptions,
-  danceStyleOptions,
-  danceSizeOptions,
-  performanceToEdit = null,
-  setPerformanceToEdit,
+  getPerformance,
+  performance,
 }) {
+  const { event: eventId } = Navigation.useContainer();
+
   const [danceTitle, setDanceTitle] = useState('');
   const [dancersString, setDancersString] = useState('');
   const [choreographersString, setChoreographersString] = useState('');
@@ -29,6 +26,67 @@ export default function PerformanceModal({
   const [competitionLevel, setCompetitionLevel] = useState(null);
   const [danceStyle, setDanceStyle] = useState(null);
   const [danceSize, setDanceSize] = useState(null);
+
+  // Dropdown options
+  const [schoolDropdownOptions, setSchoolDropdownOptions] = useState([]);
+  const [performanceLevelDropdownOptions, setPerformanceLevelDropdownOptions] = useState([]);
+  const [danceStyleDropdownOptions, setDanceStyleDropdownOptions] = useState([]);
+  const [danceSizeDropdownOptions, setDanceSizeDropdownOptions] = useState([]);
+
+  const getFilters = async () => {
+    setLoading(true);
+
+    const getSchools = async () => {
+      try {
+        const response = await axios({
+          method: 'GET',
+          url: '/api/schools/collect',
+        });
+        const schools = formatSchools(response.data);
+
+        // Modal dropdown options
+        setSchoolDropdownOptions(
+          formatDropdownOptions(schools, {
+            value: 'id',
+            label: 'schoolName',
+          })
+        );
+      } catch {
+        // Empty catch block
+      }
+    };
+
+    const getSettings = async () => {
+      const response = await axios({
+        method: 'GET',
+        url: '/api/settings/collect',
+      });
+      const settings = response.data;
+
+      const performanceLevelSettings = settings.filter(
+        setting => setting.type === 'COMPETITION_LEVEL'
+      );
+      const danceStyleSettings = settings.filter(setting => setting.type === 'STYLE');
+      const danceSizeSettings = settings.filter(setting => setting.type === 'DANCE_SIZE');
+
+      const formatOptionsFields = {
+        value: 'id',
+        label: 'value',
+      };
+
+      // Modal dropdown options
+      setPerformanceLevelDropdownOptions(
+        formatDropdownOptions(performanceLevelSettings, formatOptionsFields)
+      );
+      setDanceStyleDropdownOptions(formatDropdownOptions(danceStyleSettings, formatOptionsFields));
+      setDanceSizeDropdownOptions(formatDropdownOptions(danceSizeSettings, formatOptionsFields));
+    };
+
+    await getSchools();
+    await getSettings();
+
+    setLoading(false);
+  };
 
   const clearFields = () => {
     setDanceTitle('');
@@ -41,32 +99,12 @@ export default function PerformanceModal({
   };
 
   const onCancel = () => {
-    setPerformanceToEdit(null);
-    setOpen(false);
-    clearFields();
-  };
-
-  const onSubmit = async () => {
-    await addPerformance({
-      danceTitle,
-      dancersString,
-      choreographersString,
-      school: school.value,
-      competitionLevel: competitionLevel.label,
-      competitionLevelID: competitionLevel.value,
-      danceStyle: danceStyle.label,
-      danceStyleID: danceStyle.value,
-      danceSize: danceSize.label,
-      danceSizeID: danceSize.value,
-    });
-
-    setPerformanceToEdit(null);
     setOpen(false);
     clearFields();
   };
 
   const updatePerformance = async () => {
-    const { id } = performanceToEdit;
+    const { id } = performance;
     setLoading(true);
 
     try {
@@ -87,24 +125,27 @@ export default function PerformanceModal({
           danceStyle: danceStyle.label,
           danceStyleID: danceStyle.value,
           danceTitle,
-          eventID: EVENT_ID,
+          eventID: eventId,
           schoolID: school.value,
         },
       });
 
-      getPerformances();
+      getPerformance();
     } catch {
       // Empty catch block
     }
 
     setLoading(false);
-    setPerformanceToEdit(null);
     setOpen(false);
     clearFields();
   };
 
   useEffect(() => {
-    if (performanceToEdit) {
+    getFilters();
+  }, []);
+
+  useEffect(() => {
+    if (performance) {
       const {
         danceTitle,
         performers,
@@ -117,7 +158,7 @@ export default function PerformanceModal({
         danceStyleID,
         danceSize,
         danceSizeID,
-      } = performanceToEdit;
+      } = performance;
       setDanceTitle(danceTitle);
       setDancersString(performers.join(', '));
       setChoreographersString(choreographers.join(', '));
@@ -125,21 +166,19 @@ export default function PerformanceModal({
       setCompetitionLevel({ label: performanceLevel, value: performanceLevelID });
       setDanceStyle({ label: danceStyle, value: danceStyleID });
       setDanceSize({ label: danceSize, value: danceSizeID });
-    } else {
-      clearFields();
     }
-  }, [performanceToEdit]);
+  }, [performance]);
 
   return (
     <Modal
       containerClassName={styles.modal__container}
-      title={performanceToEdit !== null ? 'Edit Performance' : 'New Performance'}
+      title={'Edit Performance'}
       open={open}
       setModalOpen={setOpen}
       cancelText="Discard"
-      submitText={performanceToEdit !== null ? 'Edit Performance' : 'Add Performance'}
+      submitText={'Edit Performance'}
       onCancel={onCancel}
-      onSubmit={performanceToEdit !== null ? updatePerformance : onSubmit}
+      onSubmit={updatePerformance}
     >
       <div className={styles.modal}>
         <div>
@@ -173,7 +212,7 @@ export default function PerformanceModal({
           <Dropdown
             className={styles.modal__dropdown}
             placeholder="School"
-            options={schoolOptions}
+            options={schoolDropdownOptions}
             selected={school}
             onChange={school => setSchool(school)}
           />
@@ -183,7 +222,7 @@ export default function PerformanceModal({
           <Dropdown
             className={styles.modal__dropdown}
             placeholder="Level"
-            options={performanceLevelOptions}
+            options={performanceLevelDropdownOptions}
             selected={competitionLevel}
             onChange={competitionLevel => setCompetitionLevel(competitionLevel)}
           />
@@ -193,7 +232,7 @@ export default function PerformanceModal({
           <Dropdown
             className={styles.modal__dropdown}
             placeholder="Style"
-            options={danceStyleOptions}
+            options={danceStyleDropdownOptions}
             selected={danceStyle}
             onChange={danceStyle => setDanceStyle(danceStyle)}
           />
@@ -203,7 +242,7 @@ export default function PerformanceModal({
           <Dropdown
             className={styles.modal__dropdown}
             placeholder="Size"
-            options={danceSizeOptions}
+            options={danceSizeDropdownOptions}
             selected={danceSize}
             onChange={danceSize => setDanceSize(danceSize)}
           />
@@ -213,29 +252,33 @@ export default function PerformanceModal({
   );
 }
 
-PerformanceModal.propTypes = {
+EditPerformanceModal.propTypes = {
   addPerformance: PropTypes.func,
-  danceSizeOptions: PropTypes.any,
-  danceStyleOptions: PropTypes.any,
-  getPerformances: PropTypes.func,
+  getPerformance: PropTypes.func,
   open: PropTypes.any,
-  performanceLevelOptions: PropTypes.any,
-  performanceToEdit: PropTypes.shape({
+  performance: PropTypes.shape({
     choreographers: PropTypes.shape({
       join: PropTypes.func,
     }),
     competition_level: PropTypes.any,
+    danceSize: PropTypes.any,
+    danceSizeID: PropTypes.any,
+    danceStyle: PropTypes.any,
+    danceStyleID: PropTypes.any,
+    danceTitle: PropTypes.any,
     dance_size: PropTypes.any,
     dance_style: PropTypes.any,
     dance_title: PropTypes.any,
     id: PropTypes.any,
+    performanceLevel: PropTypes.any,
+    performanceLevelID: PropTypes.any,
     performers: PropTypes.shape({
       join: PropTypes.func,
     }),
+    schoolId: PropTypes.any,
+    schoolName: PropTypes.any,
     school_id: PropTypes.any,
   }),
-  schoolOptions: PropTypes.any,
   setLoading: PropTypes.func,
   setOpen: PropTypes.func,
-  setPerformanceToEdit: PropTypes.func,
 };

--- a/components/performance-details/PerformanceSummary.js
+++ b/components/performance-details/PerformanceSummary.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import Button from '@components/Button'; // Button
 import ScoreCard from '@components/ScoreCard'; // Score Card
 import styles from '@styles/components/performance-details/PerformanceSummary.module.scss'; // Component styles
 
-export default function PerformanceSummary({ performance }) {
+export default function PerformanceSummary({ performance, setModalOpen }) {
   const {
     audioRecordingLink,
     performers,
@@ -25,6 +25,9 @@ export default function PerformanceSummary({ performance }) {
           <a href={audioRecordingLink || undefined} target="_blank" rel="noreferrer noopener">
             Watch Performance
           </a>
+          <Button variant="outlined" onClick={() => setModalOpen(true)}>
+            Edit
+          </Button>
         </div>
         <div className={styles.performance__summary_performanceInfo}>
           <div>

--- a/components/performances/AddPerformanceModal.js
+++ b/components/performances/AddPerformanceModal.js
@@ -1,0 +1,166 @@
+import React, { useState } from 'react'; // React
+import PropTypes from 'prop-types'; // PropTypes
+
+import Input from '@components/Input'; // Input
+import Modal from '@components/Modal'; // Modal
+import Dropdown from '@components/Dropdown'; // Dropdown
+import styles from '@styles/components/performances/PerformanceModal.module.scss'; // Component styles
+
+export default function AddPerformanceModal({
+  open,
+  setOpen,
+  addPerformance,
+  schoolOptions,
+  performanceLevelOptions,
+  danceStyleOptions,
+  danceSizeOptions,
+}) {
+  const [danceTitle, setDanceTitle] = useState('');
+  const [dancersString, setDancersString] = useState('');
+  const [choreographersString, setChoreographersString] = useState('');
+  const [school, setSchool] = useState(null);
+  const [competitionLevel, setCompetitionLevel] = useState(null);
+  const [danceStyle, setDanceStyle] = useState(null);
+  const [danceSize, setDanceSize] = useState(null);
+
+  const clearFields = () => {
+    setDanceTitle('');
+    setDancersString('');
+    setChoreographersString('');
+    setSchool(null);
+    setCompetitionLevel(null);
+    setDanceStyle(null);
+    setDanceSize(null);
+  };
+
+  const onCancel = () => {
+    setOpen(false);
+    clearFields();
+  };
+
+  const onSubmit = async () => {
+    await addPerformance({
+      danceTitle,
+      dancersString,
+      choreographersString,
+      school: school.value,
+      competitionLevel: competitionLevel.label,
+      competitionLevelID: competitionLevel.value,
+      danceStyle: danceStyle.label,
+      danceStyleID: danceStyle.value,
+      danceSize: danceSize.label,
+      danceSizeID: danceSize.value,
+    });
+
+    setOpen(false);
+    clearFields();
+  };
+
+  return (
+    <Modal
+      containerClassName={styles.modal__container}
+      title={'New Performance'}
+      open={open}
+      setModalOpen={setOpen}
+      cancelText="Discard"
+      submitText={'Add Performance'}
+      onCancel={onCancel}
+      onSubmit={onSubmit}
+    >
+      <div className={styles.modal}>
+        <div>
+          <h2>Dance Title</h2>
+          <Input
+            placeholder="Title"
+            value={danceTitle}
+            onChange={event => setDanceTitle(event.target.value)}
+          />
+        </div>
+        <div>
+          <h2>Dancer(s)</h2>
+          <Input
+            placeholder="names, names, names"
+            value={dancersString}
+            onChange={event => setDancersString(event.target.value)}
+          />
+          <h3>Separated by comma (ie: John Smith, Jane Doe...)</h3>
+        </div>
+        <div>
+          <h2>Choreographer(s)</h2>
+          <Input
+            placeholder="names, names"
+            value={choreographersString}
+            onChange={event => setChoreographersString(event.target.value)}
+          />
+          <h3>Separated by comma (ie: John Smith, Jane Doe...)</h3>
+        </div>
+        <div>
+          <h2>School</h2>
+          <Dropdown
+            className={styles.modal__dropdown}
+            placeholder="School"
+            options={schoolOptions}
+            selected={school}
+            onChange={school => setSchool(school)}
+          />
+        </div>
+        <div>
+          <h2>Competition Level</h2>
+          <Dropdown
+            className={styles.modal__dropdown}
+            placeholder="Level"
+            options={performanceLevelOptions}
+            selected={competitionLevel}
+            onChange={competitionLevel => setCompetitionLevel(competitionLevel)}
+          />
+        </div>
+        <div>
+          <h2>Style</h2>
+          <Dropdown
+            className={styles.modal__dropdown}
+            placeholder="Style"
+            options={danceStyleOptions}
+            selected={danceStyle}
+            onChange={danceStyle => setDanceStyle(danceStyle)}
+          />
+        </div>
+        <div>
+          <h2>Size</h2>
+          <Dropdown
+            className={styles.modal__dropdown}
+            placeholder="Size"
+            options={danceSizeOptions}
+            selected={danceSize}
+            onChange={danceSize => setDanceSize(danceSize)}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}
+
+AddPerformanceModal.propTypes = {
+  addPerformance: PropTypes.func,
+  danceSizeOptions: PropTypes.any,
+  danceStyleOptions: PropTypes.any,
+  getPerformances: PropTypes.func,
+  open: PropTypes.any,
+  performanceLevelOptions: PropTypes.any,
+  performanceToEdit: PropTypes.shape({
+    choreographers: PropTypes.shape({
+      join: PropTypes.func,
+    }),
+    competition_level: PropTypes.any,
+    dance_size: PropTypes.any,
+    dance_style: PropTypes.any,
+    dance_title: PropTypes.any,
+    id: PropTypes.any,
+    performers: PropTypes.shape({
+      join: PropTypes.func,
+    }),
+    school_id: PropTypes.any,
+  }),
+  schoolOptions: PropTypes.any,
+  setLoading: PropTypes.func,
+  setOpen: PropTypes.func,
+};

--- a/components/performances/PerformancesTable.js
+++ b/components/performances/PerformancesTable.js
@@ -1,41 +1,17 @@
 import React from 'react'; // React
 import PropTypes from 'prop-types'; // PropTypes
-// import { useRouter } from 'next/router'; // Routing
+import { useRouter } from 'next/router'; // Routing
 
 import JudgingStatusPill from '@components/performances/JudgingStatusPill'; // Judging status pill
 import EmptyTableComponent from '@components/performances/EmptyTableComponent'; // Empty table component
 import Table from '@components/Table'; // Table
-import Button from '@components/Button'; // Button
 
 const PAGE_SIZE = 20; // Rows per page
 
-export default function PerformancesTable({
-  performances,
-  setPerformanceToEdit,
-  setModalOpen,
-  ...props
-}) {
-  // const router = useRouter(); // Collect router
+export default function PerformancesTable({ performances, ...props }) {
+  const router = useRouter();
 
   const columns = [
-    {
-      Header: 'Edit',
-      accessor: 'edit',
-      // eslint-disable-next-line react/display-name
-      Cell: ({ row: { original } }) => (
-        <Button
-          variant="edit"
-          onClick={() => {
-            setPerformanceToEdit(original);
-            setModalOpen(true);
-          }}
-        />
-      ),
-    },
-    {
-      Header: 'ID',
-      accessor: 'id',
-    },
     {
       Header: 'Title',
       accessor: 'danceTitle',
@@ -47,7 +23,7 @@ export default function PerformancesTable({
       filter: 'matchEnum',
     },
     {
-      Header: 'Level',
+      Header: 'Perf. Lvl',
       accessor: 'performanceLevel',
       filter: 'matchEnum',
     },
@@ -60,11 +36,6 @@ export default function PerformancesTable({
       Header: 'Size',
       accessor: 'danceSize',
       filter: 'matchEnum',
-    },
-    {
-      Header: 'Score',
-      accessor: 'score',
-      Cell: ({ value }) => (value !== null ? String(value) : 'N/A'),
     },
     // Judging view columns
     {
@@ -104,10 +75,9 @@ export default function PerformancesTable({
     },
   ];
 
-  // const goToPerformanceDetails = row => {
-  //   // Go to /performances/[id] page
-  //   router.push(`/performances/${row.id}`); // Route to "/performance/:id" page
-  // };
+  const goToPerformanceDetails = row => {
+    router.push(`/performances/${row.original.id}`); // Route to "/performance/:id" page
+  };
 
   return (
     <Table
@@ -116,7 +86,8 @@ export default function PerformancesTable({
       pageSize={PAGE_SIZE}
       emptyComponent={<EmptyTableComponent />}
       initialSort={[{ id: 'id' }]}
-      // onRowClick={goToPerformanceDetails}
+      onRowClick={goToPerformanceDetails}
+      clickable
       {...props}
     />
   );

--- a/pages/performances/[id].js
+++ b/pages/performances/[id].js
@@ -10,6 +10,7 @@ import Tab from '@components/performance-details/Tab'; // Tab
 import EmptyComponent from '@components/performance-details/EmptyComponent'; // EmptyComponent
 import JudgeFeedback from '@components/performance-details/JudgeFeedback'; // JudgeFeedback
 import PerformanceSummary from '@components/performance-details/PerformanceSummary'; // PerformanceSummary
+import EditPerformanceModal from '@components/performance-details/EditPerformanceModal'; // Edit Performance Modal
 
 import Loader from 'react-loader-spinner'; // Loading spinner
 import Title from '@components/Title'; // Title
@@ -22,6 +23,7 @@ export default function PerformanceDetails() {
   const { id } = router.query;
   const { event: eventId } = Navigation.useContainer();
 
+  const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [performance, setPerformance] = useState(null);
   const [selectedTab, setSelectedTab] = useState(-1);
@@ -47,7 +49,6 @@ export default function PerformanceDetails() {
       const response = await axios({
         method: 'post', // TODO: Fix
         url: `/api/settings/awards`,
-        // url: `/api/awards/collect?eventID=${eventId}`,
         data: {
           eventID: eventId,
           settingIDs: [dance_size_id, dance_style_id, competition_level_id],
@@ -138,7 +139,7 @@ export default function PerformanceDetails() {
               }`}
             >
               {performance && showPerformanceDetails ? (
-                <PerformanceSummary performance={performance} />
+                <PerformanceSummary performance={performance} setModalOpen={setModalOpen} />
               ) : performance && showJudgeFeedback ? (
                 <JudgeFeedback
                   getPerformance={getPerformance}
@@ -154,6 +155,13 @@ export default function PerformanceDetails() {
           </div>
         </>
       )}
+      <EditPerformanceModal
+        open={modalOpen}
+        setOpen={setModalOpen}
+        setLoading={setLoading}
+        getPerformance={getPerformance}
+        performance={performance}
+      />
     </Layout>
   );
 }

--- a/pages/performances/index.js
+++ b/pages/performances/index.js
@@ -7,7 +7,7 @@ import { getSession } from 'next-auth/client'; // Session handling
 import { useRouter } from 'next/router'; // Routing
 
 import PerformancesTable from '@components/performances/PerformancesTable'; // Performances table
-import PerformanceModal from '@components/performances/PerformanceModal'; // Performance modal
+import AddPerformanceModal from '@components/performances/AddPerformanceModal'; // Performance modal
 
 import Loader from 'react-loader-spinner'; // Loading spinner
 import Button from '@components/Button'; // Button
@@ -27,20 +27,8 @@ import styles from '@styles/pages/Performances.module.scss'; // Page styles
 import { formatSchools } from '@utils/schools'; // Format schools util
 import { formatPerformances } from '@utils/performances'; // Format performances util
 
-const ENTRY_VIEW_HIDDEN_COLUMNS = [
-  'technicalScore',
-  'artisticScore',
-  'cumulativeScore',
-  'awardsString',
-  'status',
-];
-const JUDGING_VIEW_HIDDEN_COLUMNS = [
-  'schoolName',
-  'performanceLevel',
-  'danceStyle',
-  'danceSize',
-  'score',
-];
+const ENTRY_VIEW_HIDDEN_COLUMNS = ['technicalScore', 'artisticScore', 'awardsString', 'status'];
+const JUDGING_VIEW_HIDDEN_COLUMNS = ['schoolName', 'performanceLevel', 'danceStyle', 'danceSize'];
 
 /**
  * Get the active filters from an object of filter dropdown values
@@ -256,23 +244,6 @@ export default function Performances() {
     setLoading(false);
   };
 
-  // const getAdjudications = async () => {
-  //   setLoading(true);
-
-  //   try {
-  //     const response = await axios({
-  //       method: 'GET',
-  //       url: `/api/performances/getJudgingData?eventId=${event}`,
-  //     });
-  //     const adjudicationsData = response.data;
-  //     setAdjudications(formatPerformancesForJudgingTable(adjudicationsData));
-  //   } catch {
-  //     // Empty catch block
-  //   }
-
-  //   setLoading(false);
-  // };
-
   // Get initial filter options and performances
   useEffect(() => {
     if (event === null) {
@@ -485,8 +456,6 @@ export default function Performances() {
                   filters={tableFilters}
                   pageNumber={pageNumber}
                   setPageCount={setPageCount}
-                  setPerformanceToEdit={setPerformanceToEdit}
-                  setModalOpen={setModalOpen}
                   hiddenColumns={JUDGING_VIEW_HIDDEN_COLUMNS}
                 />
               )
@@ -494,7 +463,7 @@ export default function Performances() {
           />
         </div>
       </div>
-      <PerformanceModal
+      <AddPerformanceModal
         open={modalOpen}
         setOpen={setModalOpen}
         setLoading={setLoading}

--- a/styles/components/performance-details/PerformanceSummary.module.scss
+++ b/styles/components/performance-details/PerformanceSummary.module.scss
@@ -5,8 +5,12 @@
   box-sizing: border-box;
 
   .performance__summary_performanceLink {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
     margin-bottom: 30px;
 
+    // Watch performance link
     & > a {
       font-family: DM Sans;
       font-style: normal;
@@ -17,6 +21,11 @@
 
       color: var(--system-light-blue);
       cursor: pointer;
+    }
+
+    // Edit performance button
+    & > button {
+      height: 40px;
     }
   }
 


### PR DESCRIPTION
- Removed the edit button from the Performances Table. When clicking on a row, the user will be linked to the Performance Details page for the selected performance
- In the Performance Modal, separated the Add functionality from the Edit functionality. Create is now the only option on the Performances Table page. Edit must be done through the Performance Details page

![image](https://user-images.githubusercontent.com/30249230/113486059-ded19780-947e-11eb-8c1b-d781e145c35e.png)
![image](https://user-images.githubusercontent.com/30249230/113486099-06c0fb00-947f-11eb-9e14-f352c5c13a7c.png)
![image](https://user-images.githubusercontent.com/30249230/113486107-12142680-947f-11eb-9f11-6387d3d8ca39.png)
