### PR TITLE
[Bugfix]: Disable button while in loading state

### DIFF
--- a/components/awards/AwardModal.js
+++ b/components/awards/AwardModal.js
@@ -14,6 +14,7 @@ export default function AwardModal({
   awardTypeOptions,
   performanceLevelOptions,
   createAward,
+  loading,
 }) {
   const [awardTitle, setAwardTitle] = useState('');
   const [awardType, setAwardType] = useState(null);
@@ -61,7 +62,7 @@ export default function AwardModal({
       submitText={mode === 'edit' ? 'Confirm Edit' : 'Add Award'}
       onCancel={discardChanges}
       onSubmit={onSubmit}
-      disableSubmitButton={disableButton}
+      disableSubmitButton={loading || disableButton}
     >
       <div className={styles.modal}>
         <div>
@@ -69,7 +70,7 @@ export default function AwardModal({
           <Input className={styles.modal__entryId} placeholder="Title" onChange={handleOnChange} />
         </div>
         <div>
-          <h2>Elligible dance categories</h2>
+          <h2>Eligible dance categories</h2>
           <h3>
             Select categories that apply to the potential winners of this award. (Selecting no
             categories will mean that all performances are elligible for this award).

--- a/components/awards/ScoreBasedAwards.js
+++ b/components/awards/ScoreBasedAwards.js
@@ -77,6 +77,8 @@ export default function Performances({ award }) {
   }, [query]);
 
   async function nominate() {
+    setLoading(true);
+
     try {
       await axios({
         method: 'POST',
@@ -90,6 +92,8 @@ export default function Performances({ award }) {
     } catch {
       // Empty catch block
     }
+
+    setLoading(false);
   }
 
   async function finalizeAward() {
@@ -183,6 +187,7 @@ export default function Performances({ award }) {
           }, 500);
           setPerformanceToFinalize(-1);
         }}
+        disableSubmitButton={loading}
       >
         <p>This award will now be shown in the “Finalized” tab.</p>
       </Modal>

--- a/components/performance-details/EditPerformanceModal.js
+++ b/components/performance-details/EditPerformanceModal.js
@@ -13,6 +13,7 @@ import { formatSchools } from '@utils/schools'; // Format schools util
 export default function EditPerformanceModal({
   open,
   setOpen,
+  loading,
   setLoading,
   getPerformance,
   performance,
@@ -182,6 +183,7 @@ export default function EditPerformanceModal({
       submitText={'Edit Performance'}
       onCancel={onCancel}
       onSubmit={updatePerformance}
+      disableSubmitButton={loading}
     >
       <div className={styles.modal}>
         <div>

--- a/components/performance-details/JudgeFeedback.js
+++ b/components/performance-details/JudgeFeedback.js
@@ -19,6 +19,7 @@ const DANCE_ARTISTRY_AWARD_TYPE = 'DANCE_ARTISTRY';
 
 export default function JudgeFeedback({
   getPerformance = () => {},
+  loading,
   setLoading = () => {},
   awardsDict,
   adjudication,
@@ -183,6 +184,7 @@ export default function JudgeFeedback({
                   setEditMode(false);
                 }}
                 className={styles.judge__feedback_buttons_spacing}
+                disabled={loading}
               >
                 Cancel
               </Button>
@@ -191,6 +193,7 @@ export default function JudgeFeedback({
                   updateFeedback();
                   setEditMode(false);
                 }}
+                disabled={loading}
               >
                 Save
               </Button>

--- a/components/performances/AddPerformanceModal.js
+++ b/components/performances/AddPerformanceModal.js
@@ -7,6 +7,7 @@ import Dropdown from '@components/Dropdown'; // Dropdown
 import styles from '@styles/components/performances/PerformanceModal.module.scss'; // Component styles
 
 export default function AddPerformanceModal({
+  loading,
   open,
   setOpen,
   addPerformance,
@@ -66,6 +67,7 @@ export default function AddPerformanceModal({
       submitText={'Add Performance'}
       onCancel={onCancel}
       onSubmit={onSubmit}
+      disableSubmitButton={loading}
     >
       <div className={styles.modal}>
         <div>

--- a/components/settings/AdminModal.js
+++ b/components/settings/AdminModal.js
@@ -22,6 +22,7 @@ const ADMIN_ROLE_OPTIONS = [
   },
 ];
 export default function AdminModal({
+  loading,
   setLoading,
   open,
   setOpen,
@@ -111,7 +112,7 @@ export default function AdminModal({
         clearFields();
       }}
       onSubmit={adminToEdit ? updateAdmin : addAdmin}
-      disableSubmitButton={!adminName || !adminEmail}
+      disableSubmitButton={loading || !adminName || !adminEmail}
     >
       <div className={styles.adminModal}>
         <div>

--- a/components/settings/SchoolModal.js
+++ b/components/settings/SchoolModal.js
@@ -7,6 +7,7 @@ import Input from '@components/Input'; // Input
 import styles from '@styles/components/settings/SchoolModal.module.scss'; // Component styles
 
 export default function SchoolModal({
+  loading,
   setLoading,
   open,
   setOpen,
@@ -102,7 +103,7 @@ export default function SchoolModal({
         clearFields();
       }}
       onSubmit={schoolToEdit ? updateSchool : addSchool}
-      disableSubmitButton={!schoolName || !contactName || !contactEmail || !phoneNumber}
+      disableSubmitButton={loading || !schoolName || !contactName || !contactEmail || !phoneNumber}
     >
       <div className={styles.schoolModal}>
         <div>

--- a/pages/awards/[id].js
+++ b/pages/awards/[id].js
@@ -128,6 +128,7 @@ function AwardDetails({ award }) {
           <Button
             className={styles.award_details__delete_button}
             onClick={() => setDeleteConfirmationModalOpen(true)}
+            disabled={loading}
           >
             Delete Award
           </Button>
@@ -193,6 +194,7 @@ function AwardDetails({ award }) {
           isAwardFinalized ? unfinalizeAward() : finalizeAward();
           setPerformanceToFinalize(-1);
         }}
+        disableSubmitButton={loading}
       >
         {loading ? (
           <Loader type="Oval" color="#6B778C" height={40} width={40} />
@@ -211,6 +213,7 @@ function AwardDetails({ award }) {
         setModalOpen={setDeleteConfirmationModalOpen}
         onCancel={() => setDeleteConfirmationModalOpen(false)}
         onSubmit={deleteAward}
+        disableSubmitButton={loading}
       >
         <p>Are you sure you want to delete this award?</p>
       </Modal>
@@ -293,6 +296,7 @@ const JudgeFeedback = ({
                 setConfirmationModalOpen(true);
                 setPerformanceToFinalize(feedback.id);
               }}
+              disabled={loading}
             >
               Remove Winner
             </Button>
@@ -303,6 +307,7 @@ const JudgeFeedback = ({
                 setConfirmationModalOpen(true);
                 setPerformanceToFinalize(feedback.id);
               }}
+              disabled={loading}
             >
               Finalize
             </Button>

--- a/pages/awards/index.js
+++ b/pages/awards/index.js
@@ -301,7 +301,7 @@ export default function Awards() {
               Filters
               <img src={showFilters ? ChevronDown : ChevronDownGrey} />
             </Button>
-            <Button variant="contained" onClick={() => setModalOpen(true)}>
+            <Button variant="contained" onClick={() => setModalOpen(true)} disabled={loading}>
               Add Award
             </Button>
           </div>
@@ -365,6 +365,7 @@ export default function Awards() {
         performanceLevelOptions={performanceLevelDropdownOptions}
         awardTypeOptions={awardTypeDropdownOptions}
         createAward={createAward}
+        loading={loading}
       />
     </Layout>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -209,11 +209,13 @@ function NewEvent({ judgeOptions, setModalOpen, reloadEvents }) {
   const [title, setTitle] = useState(''); // Event title
   const [date, setDate] = useState(new Date()); // Event date
   const [judges, setJudges] = useState([null, null, null]); // Event judges
+  const [loading, setLoading] = useState(false);
 
   /**
    * Submits new event creation
    */
   const submitEvent = async () => {
+    setLoading(true);
     // Post /api/events/create
     await axios.post('/api/events/create', {
       // With required data
@@ -224,6 +226,7 @@ function NewEvent({ judgeOptions, setModalOpen, reloadEvents }) {
 
     reloadEvents(); // Begin reloading all events in background
     setModalOpen(false); // Close modal
+    setLoading(false);
   };
 
   /**
@@ -295,7 +298,12 @@ function NewEvent({ judgeOptions, setModalOpen, reloadEvents }) {
         </Button>
 
         {/* Create event button */}
-        <Button variant="contained" style={{ marginLeft: '32px' }} onClick={submitEvent}>
+        <Button
+          variant="contained"
+          style={{ marginLeft: '32px' }}
+          onClick={submitEvent}
+          disabled={loading}
+        >
           Add Event
         </Button>
       </div>
@@ -315,11 +323,13 @@ function EditEvent({ event, judgeOptions, setModalOpen, reloadEvents }) {
   const [title, setTitle] = useState(event.name); // Event title
   const [judges, setJudges] = useState(event.judges.map(email => ({ label: email, value: email }))); // Event judges
   const [date, setDate] = useState(new Date(event.event_date)); // Event date
+  const [loading, setLoading] = useState(false);
 
   /**
    * Edits event
    */
   const editEvent = async () => {
+    setLoading(true);
     // Post /api/events/edit
     await axios.post('/api/events/edit', {
       // With id of event to edit
@@ -332,6 +342,7 @@ function EditEvent({ event, judgeOptions, setModalOpen, reloadEvents }) {
 
     reloadEvents(); // Begin reloading events in background
     setModalOpen(false); // Close modal
+    setLoading(false);
   };
 
   /**
@@ -418,7 +429,12 @@ function EditEvent({ event, judgeOptions, setModalOpen, reloadEvents }) {
         </Button>
 
         {/* Create event button */}
-        <Button variant="contained" style={{ marginLeft: '32px' }} onClick={editEvent}>
+        <Button
+          variant="contained"
+          style={{ marginLeft: '32px' }}
+          onClick={editEvent}
+          disabled={loading}
+        >
           Save Edits
         </Button>
       </div>

--- a/pages/performances/[id].js
+++ b/pages/performances/[id].js
@@ -143,6 +143,7 @@ export default function PerformanceDetails() {
               ) : performance && showJudgeFeedback ? (
                 <JudgeFeedback
                   getPerformance={getPerformance}
+                  loading={loading}
                   setLoading={setLoading}
                   awardsDict={awardsDict}
                   adjudication={currentAdjudication}
@@ -158,6 +159,7 @@ export default function PerformanceDetails() {
       <EditPerformanceModal
         open={modalOpen}
         setOpen={setModalOpen}
+        loading={loading}
         setLoading={setLoading}
         getPerformance={getPerformance}
         performance={performance}

--- a/pages/performances/index.js
+++ b/pages/performances/index.js
@@ -381,7 +381,7 @@ export default function Performances() {
               Filters
               <img src={showFilters ? ChevronDown : ChevronDownGrey} />
             </Button>
-            <Button variant="contained" onClick={() => setModalOpen(true)}>
+            <Button variant="contained" onClick={() => setModalOpen(true)} disabled={loading}>
               Add Performance
             </Button>
           </div>
@@ -464,6 +464,7 @@ export default function Performances() {
         </div>
       </div>
       <AddPerformanceModal
+        loading={loading}
         open={modalOpen}
         setOpen={setModalOpen}
         setLoading={setLoading}

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -358,10 +358,12 @@ export default function Setting() {
         setModalOpen={setModalOpen}
         onCancel={() => setModalOpen(false)}
         onSubmit={handleDeleteValue}
+        disableSubmitButton={loading}
       >
         <p>Deleted category values cannot be restored.</p>
       </Modal>
       <SchoolModal
+        loading={loading}
         setLoading={setLoading}
         open={schoolModalOpen}
         setOpen={setSchoolModalOpen}
@@ -370,6 +372,7 @@ export default function Setting() {
         setSchoolToEdit={setSchoolToEdit}
       />
       <AdminModal
+        loading={loading}
         setLoading={setLoading}
         open={adminModalOpen}
         setOpen={setAdminModalOpen}


### PR DESCRIPTION
Previously, buttons were still clickable after submitting a request using them. This caused event to be fired more than once, which was unideal, especially when it came to DB-modifying actions.

- Disabled all buttons that fire API requests while in loading states