### PR TITLE
[Feature]: backend validations for editing and deleting adjudications, performances, awards

### DIFF
--- a/pages/api/awards/delete.js
+++ b/pages/api/awards/delete.js
@@ -20,6 +20,26 @@ export default async (req, res) => {
     });
   }
 
+  const award = await prisma.award.findUnique({
+    where: {
+      id: id,
+    },
+  });
+
+  // If the award does not exist, throw an error
+  if (!award) {
+    return res.status(400).json({
+      error: 'Award does not exist',
+    });
+  }
+
+  // If the award is finalized, do not allow editing
+  if (award.is_finalized) {
+    return res.status(400).json({
+      error: 'Award cannot be edited as it is finalized',
+    });
+  }
+
   const deletedAwardPerformance = prisma.awardPerformance.deleteMany({
     where: {
       award_id: id,

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -44,8 +44,8 @@ export default async (req, res) => {
 
   // If the performance is finalized, we do not allow deletion
   if (performance.awards_performances && performance.awards_performances.length !== 0) {
-    for (const nomination in performance.awards_performances) {
-      if (nomination.status === 'FINALIST') {
+    for (const index in performance.awards_performances) {
+      if (performance.awards_performances[index].status === 'FINALIST') {
         return res.status(400).json({
           error: 'Performance cannot be deleted as it is finalized',
         });

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -44,8 +44,8 @@ export default async (req, res) => {
 
   // If the performance is finalized, we do not allow deletion
   if (performance.awards_performances && performance.awards_performances.length !== 0) {
-    for (const index in performance.awards_performances) {
-      if (performance.awards_performances[index].status === 'FINALIST') {
+    for (const nomination of performance.awards_performances) {
+      if (nomination.status === 'FINALIST') {
         return res.status(400).json({
           error: 'Performance cannot be deleted as it is finalized',
         });

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -18,6 +18,19 @@ export default async (req, res) => {
     });
   }
 
+  const adjudicationsExist = await prisma.adjudication.findFirst({
+    where: {
+      performance_id: id,
+    },
+  });
+
+  // If adjudications exist for the performance, do not allow editing
+  if (adjudicationsExist) {
+    return res.status(400).json({
+      error: 'Performance can not be deleted as it has an adjudication',
+    });
+  }
+
   const deletedAwardPerformance = prisma.awardPerformance.deleteMany({
     where: {
       performance_id: id,

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -18,6 +18,7 @@ export default async (req, res) => {
     });
   }
 
+  // Check if the performance has an adjudication
   const adjudicationsExist = await prisma.adjudication.findFirst({
     where: {
       performance_id: id,

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -22,6 +22,10 @@ export default async (req, res) => {
     where: {
       id: id,
     },
+    include: {
+      adjudications: true,
+      awards_performances: true,
+    },
   });
 
   // If the performance does not exist, we throw an error

--- a/pages/api/performances/delete.js
+++ b/pages/api/performances/delete.js
@@ -18,27 +18,38 @@ export default async (req, res) => {
     });
   }
 
-  // Check if the performance has an adjudication
-  const adjudicationsExist = await prisma.adjudication.findFirst({
+  const performance = await prisma.performance.findUnique({
     where: {
-      performance_id: id,
+      id: id,
     },
   });
 
-  // If adjudications exist for the performance, do not allow editing
-  if (adjudicationsExist) {
+  // If the performance does not exist, we throw an error
+  if (!performance) {
     return res.status(400).json({
-      error: 'Performance can not be deleted as it has an adjudication',
+      error: 'Performance does not exist',
     });
   }
 
-  const deletedAwardPerformance = prisma.awardPerformance.deleteMany({
-    where: {
-      performance_id: id,
-    },
-  });
+  // If the performance has adjudications, we do not allow editing
+  if (performance.adjudications && performance.adjudications.length !== 0) {
+    return res.status(400).json({
+      error: 'Performance cannot be edited as it has an adjudication',
+    });
+  }
 
-  const deletedAdjudications = prisma.adjudication.deleteMany({
+  // If the performance is finalized, we do not allow deletion
+  if (performance.awards_performances && performance.awards_performances.length !== 0) {
+    for (const nomination in performance.awards_performances) {
+      if (nomination.status === 'FINALIST') {
+        return res.status(400).json({
+          error: 'Performance cannot be deleted as it is finalized',
+        });
+      }
+    }
+  }
+
+  const deletedAwardPerformance = prisma.awardPerformance.deleteMany({
     where: {
       performance_id: id,
     },
@@ -51,7 +62,7 @@ export default async (req, res) => {
   });
 
   try {
-    await prisma.$transaction([deletedAwardPerformance, deletedAdjudications, deletedPerformance]);
+    await prisma.$transaction([deletedAwardPerformance, deletedPerformance]);
   } catch {
     return res.status(400).json({
       error: 'Error deleting performance',

--- a/pages/api/performances/edit.js
+++ b/pages/api/performances/edit.js
@@ -34,21 +34,21 @@ export default async (req, res) => {
     danceStyleID,
     competitionLevelID,
   **/
-  // if (
-  //   !id ||
-  //   !danceTitle ||
-  //   !performers ||
-  //   !choreographers ||
-  //   !competitionLevel ||
-  //   !danceSize ||
-  //   !danceStyle ||
-  //   !eventID ||
-  //   !schoolID
-  // ) {
-  //   return res.status(400).json({
-  //     error: 'Required fields to update performance were not provided',
-  //   });
-  // }
+  if (
+    !id ||
+    !danceTitle ||
+    !performers ||
+    !choreographers ||
+    !competitionLevel ||
+    !danceSize ||
+    !danceStyle ||
+    !eventID ||
+    !schoolID
+  ) {
+    return res.status(400).json({
+      error: 'Required fields to update performance were not provided',
+    });
+  }
 
   // Check that the event exists
   const eventExists = await prisma.event.findUnique({
@@ -64,6 +64,7 @@ export default async (req, res) => {
     });
   }
 
+  // Check if the performance has an adjudication
   const adjudicationsExist = await prisma.adjudication.findFirst({
     where: {
       performance_id: id,

--- a/pages/api/performances/edit.js
+++ b/pages/api/performances/edit.js
@@ -90,8 +90,8 @@ export default async (req, res) => {
 
   // If the performance is nominated for an award and it is a finalist, we do not allow editing
   if (performance.awards_performances && performance.awards_performances.length !== 0) {
-    for (const nomination in performance.awards_performances) {
-      if (nomination.status === 'FINALIST') {
+    for (const index in performance.awards_performances) {
+      if (performance.awards_performances[index].status === 'FINALIST') {
         return res.status(400).json({
           error: 'Performance cannot be edited as it is a finalist for an award',
         });

--- a/pages/api/performances/edit.js
+++ b/pages/api/performances/edit.js
@@ -68,6 +68,10 @@ export default async (req, res) => {
     where: {
       id: id,
     },
+    include: {
+      adjudications: true,
+      awards_performances: true,
+    },
   });
 
   // If the performance does not exist, throw error

--- a/pages/api/performances/edit.js
+++ b/pages/api/performances/edit.js
@@ -90,8 +90,8 @@ export default async (req, res) => {
 
   // If the performance is nominated for an award and it is a finalist, we do not allow editing
   if (performance.awards_performances && performance.awards_performances.length !== 0) {
-    for (const index in performance.awards_performances) {
-      if (performance.awards_performances[index].status === 'FINALIST') {
+    for (const nomination of performance.awards_performances) {
+      if (nomination.status === 'FINALIST') {
         return res.status(400).json({
           error: 'Performance cannot be edited as it is a finalist for an award',
         });

--- a/pages/api/performances/edit.js
+++ b/pages/api/performances/edit.js
@@ -34,21 +34,21 @@ export default async (req, res) => {
     danceStyleID,
     competitionLevelID,
   **/
-  if (
-    !id ||
-    !danceTitle ||
-    !performers ||
-    !choreographers ||
-    !competitionLevel ||
-    !danceSize ||
-    !danceStyle ||
-    !eventID ||
-    !schoolID
-  ) {
-    return res.status(400).json({
-      error: 'Required fields to update performance were not provided',
-    });
-  }
+  // if (
+  //   !id ||
+  //   !danceTitle ||
+  //   !performers ||
+  //   !choreographers ||
+  //   !competitionLevel ||
+  //   !danceSize ||
+  //   !danceStyle ||
+  //   !eventID ||
+  //   !schoolID
+  // ) {
+  //   return res.status(400).json({
+  //     error: 'Required fields to update performance were not provided',
+  //   });
+  // }
 
   // Check that the event exists
   const eventExists = await prisma.event.findUnique({
@@ -61,6 +61,19 @@ export default async (req, res) => {
   if (!eventExists) {
     return res.status(400).json({
       error: 'Event does not exist',
+    });
+  }
+
+  const adjudicationsExist = await prisma.adjudication.findFirst({
+    where: {
+      performance_id: id,
+    },
+  });
+
+  // If adjudications exist for the performance, do not allow editing
+  if (adjudicationsExist) {
+    return res.status(400).json({
+      error: 'Performance can not be edited as it has an adjudication',
     });
   }
 

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -39,6 +39,21 @@ export default async (req, res) => {
     });
   }
 
+  // Check if the performance is a finalist for even one award, it means that the performance is finalized
+  const isFinalized = await prisma.awardPerformance.findFirst({
+    where: {
+      performance_id: performanceID,
+      status: 'FINALIST',
+    },
+  });
+
+  // If it is finalized, we do not allow deleting adjudication
+  if (isFinalized) {
+    return res.status(400).json({
+      error: 'Nominations cannot be changed as performance is finalized',
+    });
+  }
+
   // TODO for now we assume frontend will filter correctly and only
   // eligible awards will show up for validation
   try {

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -45,7 +45,6 @@ export default async (req, res) => {
     },
   });
 
-  console.log(awards);
   // Even if one of the awards we are attempting to nominate the performance for is finalized, we prevent the nomination from occurring.
   if (awards && awards.length !== 0) {
     for (const id in awards) {

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -39,7 +39,24 @@ export default async (req, res) => {
     });
   }
 
-  //TODO: I think the use case doesn't make sense
+  const awards = await prisma.award.findMany({
+    where: {
+      id: { in: awardIDs },
+    },
+  });
+
+  console.log(awards);
+  // Even if one of the awards we are attempting to nominate the performance for is finalized, we prevent the nomination from occurring.
+  if (awards && awards.length !== 0) {
+    for (const id in awards) {
+      if (awards[id].is_finalized) {
+        return res.status(400).json({
+          error: 'Performance cannot be nominated as one of the awards is finalized',
+        });
+      }
+    }
+  }
+
   // Check if the performance is a finalist for even one award, it means that the performance is finalized
   const isFinalized = await prisma.awardPerformance.findFirst({
     where: {

--- a/pages/api/performances/nominate.js
+++ b/pages/api/performances/nominate.js
@@ -39,6 +39,7 @@ export default async (req, res) => {
     });
   }
 
+  //TODO: I think the use case doesn't make sense
   // Check if the performance is a finalist for even one award, it means that the performance is finalized
   const isFinalized = await prisma.awardPerformance.findFirst({
     where: {


### PR DESCRIPTION
### Deleting Adjudications (Not in frontend ATM)
- Check that adjudication exists
- If the performance associated with the adjudication is finalized, prevent deleting
- Delete all nominations with the same user_id as the user_iud in adjudication for the performance

### Edit Adjudications
- Check that adjudication exists
- If the performance associated with the adjudication is finalized, prevent editing -> Tested

### Delete Awards
- Check that award exists
- If the award is finalized, prevent deletion -> Tested

### Edit Awards (Not in frontend ATM)
- Removed ability to set is_finalized through edit endpoint
- Check that award exists
- If the award is finalized, prevent editing
- If the award has nominations, prevent editing

### Delete Performance (Not in frontend ATM)
- Check that performance exists
- If the performance has adjudications, prevent 
- If the performance is finalized, prevent deletion 
- Removed deleting award_performance records in cascading delete

### Edit Performance
- Check that performance exists 
- If the performance has adjudications, prevent editing -> Tested
- If the performance is finalized, prevent editing -> Tested

### Nominate
- If the performance is already finalized, we stop the nominations from being edited or more nominations to be added -> Tested. 
- If one of the awards attempted to be nominated is already finalized, we prevent the nominations from occurring completely. -> Tested
