### PR TITLE
[Bugfix]: Fix recording animation not showing on rerecord

### DIFF
--- a/components/performance-details/FeedbackAudio.js
+++ b/components/performance-details/FeedbackAudio.js
@@ -1,3 +1,4 @@
+import Loader from 'react-loader-spinner'; // Recording animation
 import Button from '@components/Button'; // Button
 import AudioPlayer from '@components/AudioPlayer'; // Audio player
 import AudioRecorder from '@components/AudioRecorder'; // Audio recorder
@@ -21,21 +22,32 @@ export default function FeedbackAudio({
 
   return edit ? (
     <div>
-      <div className={`${styles.audioRecorder__wrapper} ${recording ? undefined : styles.hidden}`}>
+      <div className={`${styles.audioRecorder__wrapper} ${styles.hidden}`}>
         <AudioRecorder
-          className={`${styles.audioRecorder}`}
+          className={styles.audioRecorder}
           recording={recording}
           onStopRecording={onStopRecording}
         />
       </div>
       {recording ? (
-        <Button
-          className={styles.stopButton}
-          variant="outlined"
-          onClick={() => setRecording(false)}
-        >
-          Stop
-        </Button>
+        <>
+          <div className={styles.recordingAnimation__wrapper}>
+            <Loader
+              type="Audio"
+              color="#a72a1d" // brand-other-red
+              height={32}
+              width={48}
+            />
+            <p>Recording...</p>
+          </div>
+          <Button
+            className={styles.stopButton}
+            variant="outlined"
+            onClick={() => setRecording(false)}
+          >
+            Stop
+          </Button>
+        </>
       ) : recordedBlob || audioUrl ? (
         <>
           <AudioPlayer audioUrl={recordedBlob ? recordedBlob.blobURL : audioUrl} />

--- a/styles/components/performance-details/FeedbackAudio.module.scss
+++ b/styles/components/performance-details/FeedbackAudio.module.scss
@@ -12,6 +12,19 @@
   }
 }
 
+.recordingAnimation__wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 8px;
+
+  // "Recording..."
+  p {
+    margin: 0;
+  }
+}
+
 .recordButton,
 .stopButton {
   width: 100%;


### PR DESCRIPTION
- React-mic is bugged - on rerecord, it doesn't show the recording line
- Replaced the recording line with an audio recording animation from `react-loader-spinner`

![image](https://user-images.githubusercontent.com/30249230/114640926-13bfc480-9c9f-11eb-9ed5-3f13007e03c0.png)
