### PR TITLE
[Feature]: Added validation to prevent editing event if it has performances or awards

### DIFF
--- a/pages/api/events/edit.js
+++ b/pages/api/events/edit.js
@@ -37,7 +37,7 @@ export default async (req, res) => {
 
     // check that the fields exist
     if (title && date && judges) {
-      // If the judges are different and the event has performances or awards
+      // If the judges are updated and the event has performances or awards, we want to prevent editing
       if (
         JSON.stringify(judges) !== event.judges &&
         ((event.performances && event.performances.length !== 0) ||

--- a/pages/api/events/edit.js
+++ b/pages/api/events/edit.js
@@ -12,6 +12,34 @@ export default async (req, res) => {
 
     // If all fields exist
     if (id && title && date && judges) {
+      // Check that event exists
+      const event = await prisma.event.findUnique({
+        where: {
+          id: id,
+        },
+        include: {
+          performances: true,
+          awards: true,
+        },
+      });
+
+      // If event does not exist
+      if (!event) {
+        return res.status(400).json({
+          error: 'Event does not exist',
+        });
+      }
+
+      // Check if the event has a performance or an award
+      if (
+        (event.performances && event.performances.length !== 0) ||
+        (event.awards && event.awards.length !== 0)
+      ) {
+        return res.status(400).json({
+          error: 'Event cannot be edited as there is at least one performance or award',
+        });
+      }
+
       // Update event
       const updatedEvent = await prisma.event.update({
         // Where

--- a/pages/index.js
+++ b/pages/index.js
@@ -354,31 +354,6 @@ function EditEvent({ event, judgeOptions, setModalOpen, reloadEvents }) {
     setLoading(false);
   };
 
-  // const addSchool = async () => {
-  //   setLoading(true);
-
-  //   try {
-  //     await axios({
-  //       method: 'POST',
-  //       url: '/api/schools/create',
-  //       data: {
-  //         schoolName,
-  //         contactName,
-  //         email: contactEmail,
-  //         phone: phoneNumber,
-  //       },
-  //     });
-
-  //     await getSchools();
-  //   } catch (err) {
-  //     snackbarError(err);
-  //   }
-
-  //   setLoading(false);
-  //   setOpen(false);
-  //   clearFields();
-  // };
-
   /**
    * Deletes event
    */

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,6 +16,8 @@ import DancerRedJump from '@assets/dancer-red-jump.svg'; // Jumping Dancer SVG
 import DancerRedTall from '@assets/dancer-red-tall.svg'; // Jumping Dancer SVG
 import DatePicker from '@components/DatePicker';
 
+import useSnackbar from '@utils/useSnackbar'; // Snackbar
+
 // Modal content states enum
 const modalStates = Object.freeze({
   newEvent: 0,
@@ -325,25 +327,57 @@ function EditEvent({ event, judgeOptions, setModalOpen, reloadEvents }) {
   const [date, setDate] = useState(new Date(event.event_date)); // Event date
   const [loading, setLoading] = useState(false);
 
+  const { snackbarError } = useSnackbar();
+
   /**
    * Edits event
    */
   const editEvent = async () => {
     setLoading(true);
-    // Post /api/events/edit
-    await axios.post('/api/events/edit', {
-      // With id of event to edit
-      id: event.id,
-      // And data to patch
-      title,
-      date,
-      judges: [...new Set(judges.map(judge => judge.value).filter(judge => !!judge))],
-    });
+    try {
+      // Post /api/events/edit
+      await axios.post('/api/events/edit', {
+        // With id of event to edit
+        id: event.id,
+        // And data to patch
+        title,
+        date,
+        judges: [...new Set(judges.map(judge => judge.value).filter(judge => !!judge))],
+      });
 
-    reloadEvents(); // Begin reloading events in background
+      reloadEvents(); // Begin reloading events in background
+    } catch (err) {
+      snackbarError(err);
+    }
+
     setModalOpen(false); // Close modal
     setLoading(false);
   };
+
+  // const addSchool = async () => {
+  //   setLoading(true);
+
+  //   try {
+  //     await axios({
+  //       method: 'POST',
+  //       url: '/api/schools/create',
+  //       data: {
+  //         schoolName,
+  //         contactName,
+  //         email: contactEmail,
+  //         phone: phoneNumber,
+  //       },
+  //     });
+
+  //     await getSchools();
+  //   } catch (err) {
+  //     snackbarError(err);
+  //   }
+
+  //   setLoading(false);
+  //   setOpen(false);
+  //   clearFields();
+  // };
 
   /**
    * Deletes event


### PR DESCRIPTION
- If the event has awards or performances, the backend will return a 400 error which will be displayed in the frontend.
- Allow editing event name or date but not judges if event has awards or performances
![image](https://user-images.githubusercontent.com/46411197/114949540-771c3480-9e0e-11eb-81c9-7d3a17a1cf68.png)
