### PR TITLE
[Bugfix]: Fix deleting Performance filters

### DIFF
--- a/pages/performances/index.js
+++ b/pages/performances/index.js
@@ -48,14 +48,18 @@ const getActiveFilters = options => {
 
 /**
  * Remove key from object
- * @param {Object} object - An object
+ * @param {Object} object - An object containing all the available filters
  * @param {*} key - A key in the object
  * @returns {Object} A new object that is a copy of the `object` parameter with the `key` removed
  */
-const removeKeyFromObject = (object, key) => {
-  // eslint-disable-next-line no-unused-vars
-  const { [key]: _, ...rest } = object;
-  return rest;
+const removeFilter = (object, key) => {
+  return {
+    ...object,
+    [key]: {
+      label: object[key].label,
+      selected: false,
+    },
+  };
 };
 
 // Page: Performances
@@ -328,7 +332,7 @@ export default function Performances({ session }) {
         <Pill
           key={i}
           label={label}
-          onDelete={() => setSchoolFilters(removeKeyFromObject(schoolFilters, value))}
+          onDelete={() => setSchoolFilters(removeFilter(schoolFilters, value))}
         />
       );
     });
@@ -337,9 +341,7 @@ export default function Performances({ session }) {
         <Pill
           key={i}
           label={label}
-          onDelete={() =>
-            setPerformanceLevelFilters(removeKeyFromObject(performanceLevelFilters, value))
-          }
+          onDelete={() => setPerformanceLevelFilters(removeFilter(performanceLevelFilters, value))}
         />
       );
     });
@@ -348,7 +350,7 @@ export default function Performances({ session }) {
         <Pill
           key={i}
           label={label}
-          onDelete={() => setDanceStyleFilters(removeKeyFromObject(danceStyleFilters, value))}
+          onDelete={() => setDanceStyleFilters(removeFilter(danceStyleFilters, value))}
         />
       );
     });
@@ -357,7 +359,7 @@ export default function Performances({ session }) {
         <Pill
           key={i}
           label={label}
-          onDelete={() => setDanceSizeFilters(removeKeyFromObject(danceSizeFilters, value))}
+          onDelete={() => setDanceSizeFilters(removeFilter(danceSizeFilters, value))}
         />
       );
     });

--- a/pages/performances/index.js
+++ b/pages/performances/index.js
@@ -330,7 +330,7 @@ export default function Performances({ session }) {
     activeSchoolFilters.forEach(({ label, value }, i) => {
       activeFilterPills.push(
         <Pill
-          key={i}
+          key={`school-${i}`}
           label={label}
           onDelete={() => setSchoolFilters(removeFilter(schoolFilters, value))}
         />
@@ -339,7 +339,7 @@ export default function Performances({ session }) {
     activePerformanceLevelFilters.forEach(({ label, value }, i) => {
       activeFilterPills.push(
         <Pill
-          key={i}
+          key={`performance-level-${i}`}
           label={label}
           onDelete={() => setPerformanceLevelFilters(removeFilter(performanceLevelFilters, value))}
         />
@@ -348,7 +348,7 @@ export default function Performances({ session }) {
     activeDanceStyleFilters.forEach(({ label, value }, i) => {
       activeFilterPills.push(
         <Pill
-          key={i}
+          key={`dance-style-${i}`}
           label={label}
           onDelete={() => setDanceStyleFilters(removeFilter(danceStyleFilters, value))}
         />
@@ -357,7 +357,7 @@ export default function Performances({ session }) {
     activeDanceSizeFilters.forEach(({ label, value }, i) => {
       activeFilterPills.push(
         <Pill
-          key={i}
+          key={`dance-size-${i}`}
           label={label}
           onDelete={() => setDanceSizeFilters(removeFilter(danceSizeFilters, value))}
         />


### PR DESCRIPTION
Fixes a few bugs with Performance filters:
- Deleting a filter pill deleted the actual filter option in the dropdown
- Spamming a filter option creates many duplicates of the pill, even when the filter state is current