### PR TITLE
[Feature]: Added filtering for performances for score based awards

### DIFF
--- a/components/awards/ScoreBasedAwards.js
+++ b/components/awards/ScoreBasedAwards.js
@@ -56,6 +56,7 @@ export default function Performances({ award, session }) {
   const getPerformances = async () => {
     setLoading(true);
 
+    // NOTE: If we know the specific award category, we can pass in 3 params (competition_level_id, dance_size_id, dance_level_id)
     let performanceUrl = `/api/performances/collect?eventID=${event.id}`;
     if (award.awards_categories && award.awards_categories.length !== 0) {
       performanceUrl += `&settingIDs=${award.awards_categories.join(',')}`;

--- a/components/awards/ScoreBasedAwards.js
+++ b/components/awards/ScoreBasedAwards.js
@@ -56,10 +56,15 @@ export default function Performances({ award, session }) {
   const getPerformances = async () => {
     setLoading(true);
 
+    let performanceUrl = `/api/performances/collect?eventID=${event.id}`;
+    if (award.awards_categories && award.awards_categories.length !== 0) {
+      performanceUrl += `&settingIDs=${award.awards_categories.join(',')}`;
+    }
+
     try {
       const response = await axios({
         method: 'GET',
-        url: `/api/performances/collect?eventID=${event.id}`,
+        url: performanceUrl,
       });
 
       setPerformances(formatPerformances(response.data));

--- a/pages/api/performances/collect.js
+++ b/pages/api/performances/collect.js
@@ -27,7 +27,9 @@ export default async (req, res) => {
   // If schoolIDs exist, we convert it into an array of integers to add to the filter
   if (schoolIDs) filter.school_id = { in: schoolIDs.split(',').map(i => +i) };
   if (settingIDs) {
-    // If settingIDs array is passed in, we filter foor performances with the matching settings
+    // If settingIDs array is passed in, we filter for performances with the matching settings
+    // We get all the performances where the competition_level, dance_size, dance_style are in
+    // the requested settingIDs that are passed in
     const settingIDArray = settingIDs.split(',').map(i => +i);
     filter.competition_level_id = {
       in: settingIDArray,

--- a/pages/api/performances/collect.js
+++ b/pages/api/performances/collect.js
@@ -27,24 +27,19 @@ export default async (req, res) => {
   // If schoolIDs exist, we convert it into an array of integers to add to the filter
   if (schoolIDs) filter.school_id = { in: schoolIDs.split(',').map(i => +i) };
   if (settingIDs) {
+    // If settingIDs array is passed in, we filter foor performances with the matching settings
     const settingIDArray = settingIDs.split(',').map(i => +i);
-    filter.OR = [
-      {
-        competition_level_id: {
-          in: settingIDArray,
-        },
-      },
-      {
-        dance_size_id: {
-          in: settingIDArray,
-        },
-      },
-      {
-        dance_style_id: {
-          in: settingIDArray,
-        },
-      },
-    ];
+    filter.competition_level_id = {
+      in: settingIDArray,
+    };
+
+    filter.dance_size_id = {
+      in: settingIDArray,
+    };
+
+    filter.dance_style_id = {
+      in: settingIDArray,
+    };
   }
 
   const performances = await getPerformances(filter);


### PR DESCRIPTION
- Added filtering for performances on score based awards page so that only performances eligible for the score based award are shown.

From the award_categories field of award, do we know which one corresponds to competition_level_id, dance_size_id, or dance_style_id? Right now, I have it send all the settingIDs in a list. If it's possible to know what each one corresponds to, I believe it would make the backend a bit cleaner since right now, for each of the 3 fields in performances, we're checking if the id is in the settingIDs array that's passed in.