### PR TITLE
[Bugfix]: Fix judges seeing other judges' feedback

### DIFF
--- a/pages/api/adjudications/create.js
+++ b/pages/api/adjudications/create.js
@@ -36,8 +36,7 @@ export default async (req, res) => {
   }
 
   const existingAdjudications = await prisma.adjudication.findMany({
-    performance_id: parseInt(performanceID),
-    user_id: userID,
+    where: { performance_id: parseInt(performanceID), user_id: userID },
   });
 
   if (existingAdjudications && existingAdjudications.length > 0) {

--- a/pages/performances/[id].js
+++ b/pages/performances/[id].js
@@ -43,7 +43,12 @@ export default function PerformanceDetails({ session }) {
     performance || {};
   const adjudications = initialAdjudications.sort((a, b) => (a.user.name > b.user.name ? 1 : -1));
   const eventName = event && event.name;
-  const currentAdjudication = adjudications.length > 0 ? adjudications[selectedTab] : undefined;
+  const currentAdjudication =
+    adjudications.length > 0
+      ? session.role === 'JUDGE'
+        ? adjudications.find(adjudication => adjudication.user.id === session.id)
+        : adjudications[selectedTab]
+      : undefined;
   const currentJudgeUserId = currentAdjudication && currentAdjudication.userId;
   const currentNominations =
     nominations && currentJudgeUserId ? nominations[currentJudgeUserId] : undefined;


### PR DESCRIPTION
When a judge was filling out the feedback for a performance, they were possibly shown the feedback given by another judge. This bug was due to the logic serving the adjudication not accounting for a judge.